### PR TITLE
Update Tag Component

### DIFF
--- a/src/tag/doc.mdx
+++ b/src/tag/doc.mdx
@@ -30,17 +30,23 @@ Tags highlight the metadata or progress of an item, such as wouldn't be valuable
 
 ### Props
 
+<Prop name="spreadProps" type="spread">
+  All Props not explicitly defined here will be spread into the as expected.
+</Prop>
 <Prop name="bg" type="string" defaultValue="#f9de89">
   The background color of the tag.
 </Prop>
 <Prop name="color" type="string" defaultValue="#2d2d2d">
   The font color of the tag.
 </Prop>
-<Prop name="filter" type="boolean" defaultValue="false">
+<Prop name="select" type="boolean" defaultValue="false">
   Determine variant of chip and adds accessability attributes.
 </Prop>
 <Prop name="icon" type="Element" defaultValue="null">
   Leading icon for the tag.
+</Prop>
+<Prop name="checked" type="boolean" defaultValue="false">
+  Determine variant of tag and adds accessability attributes.
 </Prop>
 <Prop name="onChange" type="function" defaultValue="(e) => null">
   Determine variant of tag and adds accessability attributes.

--- a/src/tag/doc.mdx
+++ b/src/tag/doc.mdx
@@ -68,16 +68,21 @@ Tags can contain text and icons. They display text content naturally. Icons are 
 
 <Playground>
   {() => {
-    const petPolicy = [
-      { type: "Cats", allowed: true },
-      { type: "Small Dogs", allowed: false },
-      { type: "Large Dogs", allowed: false }
-    ]
+    const initialState = {
+      Cats: false,
+      "Small Dogs": true,
+      "Large Dogs": false
+    }
+    const reducer = (state, action) => ({ ...state, ...action })
+    const [state, set] = useReducer(reducer, initialState)
+    function handleChange(e) {
+      set({ [e.target.name]: e.target.checked })
+    }
     return (
       <Fragment>
-        {petPolicy.map(({ type, allowed }) => (
-          <Tag key={type} filter checked={allowed}>
-            {type}
+        {Object.keys(state).map(key => (
+          <Tag filter key={key} name={key} checked={state[key]} onChange={handleChange}>
+            {key}
           </Tag>
         ))}
       </Fragment>

--- a/src/tag/doc.mdx
+++ b/src/tag/doc.mdx
@@ -64,7 +64,9 @@ Tags can contain text and icons. They display text content naturally. Icons are 
   <Tag bg={colors.green_300}>Leased for $1,200/mo</Tag>
 </Playground>
 
-### Filter Tags
+### Selection Tags
+
+Selection tags use descriptive words to select or filter content, they're a good alternative to checkboxes when used with a lot of choices that benefit from being inline. Tap a chip to select it, multiple chips be selected at once.
 
 <Playground>
   {() => {
@@ -81,7 +83,7 @@ Tags can contain text and icons. They display text content naturally. Icons are 
     return (
       <Fragment>
         {Object.keys(state).map(key => (
-          <Tag filter key={key} name={key} checked={state[key]} onChange={handleChange}>
+          <Tag select key={key} name={key} checked={state[key]} onChange={handleChange}>
             {key}
           </Tag>
         ))}

--- a/src/tag/doc.mdx
+++ b/src/tag/doc.mdx
@@ -4,10 +4,11 @@ route: /components/tag
 menu: Components
 ---
 
+import { Fragment, useReducer } from "react"
 import Prop from "utils/prop"
 import Status from "utils/status"
 import Playground from "utils/playground"
-import { Anchor, Calendar } from "react-feather"
+import { DollarSign, Calendar } from "react-feather"
 import { colors } from "src/constants"
 import Tag from "src/tag"
 
@@ -35,6 +36,15 @@ Tags highlight the metadata or progress of an item, such as wouldn't be valuable
 <Prop name="color" type="string" defaultValue="#2d2d2d">
   The font color of the tag.
 </Prop>
+<Prop name="filter" type="boolean" defaultValue="false">
+  Determine variant of chip and adds accessability attributes.
+</Prop>
+<Prop name="icon" type="Element" defaultValue="null">
+  Leading icon for the tag.
+</Prop>
+<Prop name="onChange" type="function" defaultValue="(e) => null">
+  Determine variant of tag and adds accessability attributes.
+</Prop>
 
 ## Usage
 
@@ -45,11 +55,32 @@ Tags highlight the metadata or progress of an item, such as wouldn't be valuable
   </Tag>
 </Playground>
 
-Tags can contain text and icons. They simply take their children and display it naturally.
+Tags can contain text and icons. They display text content naturally. Icons are passed in via an `icon` prop.
 
 <Playground>
-  <Tag bg={colors.blue_500} color={colors.ui_100}>
-    <Anchor /> Payment Made
+  <Tag bg={colors.blue_500} color={colors.ui_100} icon={DollarSign}>
+    Payment Made
   </Tag>
   <Tag bg={colors.green_300}>Leased for $1,200/mo</Tag>
+</Playground>
+
+### Filter Tags
+
+<Playground>
+  {() => {
+    const petPolicy = [
+      { type: "Cats", allowed: true },
+      { type: "Small Dogs", allowed: false },
+      { type: "Large Dogs", allowed: false }
+    ]
+    return (
+      <Fragment>
+        {petPolicy.map(({ type, allowed }) => (
+          <Tag key={type} filter checked={allowed}>
+            {type}
+          </Tag>
+        ))}
+      </Fragment>
+    )
+  }}
 </Playground>

--- a/src/tag/doc.mdx
+++ b/src/tag/doc.mdx
@@ -46,10 +46,10 @@ Tags highlight the metadata or progress of an item, such as wouldn't be valuable
   Leading icon for the tag.
 </Prop>
 <Prop name="checked" type="boolean" defaultValue="false">
-  Determine variant of tag and adds accessability attributes.
+  Determine the state of the select tag variant
 </Prop>
-<Prop name="onChange" type="function" defaultValue="(e) => null">
-  Determine variant of tag and adds accessability attributes.
+<Prop name="onChange" type="function" defaultValue="(event) => null">
+  Fires when a user changes the state of a select tag.
 </Prop>
 
 ## Usage

--- a/src/tag/index.js
+++ b/src/tag/index.js
@@ -1,75 +1,76 @@
-import React, { useState } from "react"
+import React from "react"
 import styled, { css } from "styled-components"
 import PropTypes from "prop-types"
 import { Check } from "react-feather"
 import { colors } from "../constants"
 
 const filterStyles = css`
-  cursor: pointer;
   background: ${colors.ui_300};
-  outline: none;
+  color: ${colors.ui_700};
+  cursor: pointer;
   transition: 100ms;
+  user-select: none;
   &:hover {
     background: ${colors.blue_100};
+    color: ${colors.blue_700};
   }
   &.checked {
     background: ${colors.blue_500};
     color: ${colors.ui_100};
   }
+  input[type="checkbox"] {
+    appearance: none;
+    width: 0;
+    height: 0;
+    position: absolute;
+  }
 `
 
-const StyledTag = styled.span.attrs({
-  checked: ({ isChecked }) => isChecked,
-  role: ({ filter }) => (filter ? "checkbox" : "row"),
-  tabIndex: 0,
-  "aria-checked": ({ isChecked }) => isChecked
-})`
+const StyledTag = styled.span`
+  position: relative;
   display: inline-flex;
   align-items: center;
-  font-size: 1.333rem;
-  line-height: 2rem;
-  vertical-align: center;
   padding: 0 1rem;
   border-radius: 1rem;
   background: ${({ bg }) => bg};
   color: ${({ color }) => color};
+  font-size: 1.334rem;
+  line-height: 1.5;
   svg {
-    width: 1.333rem;
-    height: 1.333rem;
+    width: 1.334rem;
+    height: 1.334rem;
     margin-right: 0.5rem;
   }
-  ${({ filter }) => filter && filterStyles};
+  ${({ isFilter }) => isFilter && filterStyles}
 `
 
 export default function Tag({
   children,
-  checked,
   className,
-  icon: Icon,
   filter,
+  icon: Icon,
+  checked,
   onChange,
   ...props
 }) {
-  const [isChecked, setIsChecked] = useState(checked)
-  function handleChange(e) {
-    setIsChecked(!isChecked)
-    onChange(e)
+  function handleCheck(e) {
+    if (onChange) onChange(e)
   }
   if (!filter)
     return (
-      <StyledTag className={className} {...props}>
-        {Icon && <Icon />} {children}
+      <StyledTag {...props}>
+        {Icon && <Icon />}
+        {children}
       </StyledTag>
     )
   return (
     <StyledTag
-      className={`${className} ${isChecked && "checked"}`}
-      onClick={handleChange}
-      filter={filter}
-      checked={isChecked}
-      {...props}
+      className={`${className} ${checked && "checked"}`}
+      as="label"
+      isFilter={filter}
     >
-      {isChecked ? <Check /> : Icon ? <Icon /> : null}
+      <input type="checkbox" onChange={handleCheck} checked={checked} {...props} />
+      {checked ? <Check /> : Icon ? <Icon /> : null}
       {children}
     </StyledTag>
   )
@@ -79,7 +80,7 @@ Tag.propTypes = {
   bg: PropTypes.string,
   color: PropTypes.string,
   checked: PropTypes.bool,
-  children: PropTypes.element,
+  children: PropTypes.node,
   className: PropTypes.string,
   filter: PropTypes.bool,
   icon: PropTypes.element,

--- a/src/tag/index.js
+++ b/src/tag/index.js
@@ -47,7 +47,7 @@ const StyledTag = styled.span`
 export default function Tag({
   children,
   className,
-  filter,
+  select,
   icon: Icon,
   checked,
   onChange,
@@ -60,7 +60,7 @@ export default function Tag({
     if (onChange) onChange(e)
     set(e.target.checked)
   }
-  if (!filter)
+  if (!select)
     return (
       <StyledTag className={className} bg={bg} color={color} {...props}>
         {Icon && <Icon />}
@@ -71,7 +71,7 @@ export default function Tag({
     <StyledTag
       className={`${className} ${internalChecked ? "checked" : ""}`}
       as="label"
-      isFilter={filter}
+      isFilter={select}
       bg={bg}
       color={color}
     >
@@ -93,7 +93,7 @@ Tag.propTypes = {
   checked: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.string,
-  filter: PropTypes.bool,
+  select: PropTypes.bool,
   icon: PropTypes.element,
   onChange: PropTypes.func
 }
@@ -104,7 +104,7 @@ Tag.defaultProps = {
   checked: false,
   children: null,
   className: "",
-  filter: false,
+  select: false,
   icon: null,
   onChange: () => null
 }

--- a/src/tag/index.js
+++ b/src/tag/index.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import styled, { css } from "styled-components"
 import PropTypes from "prop-types"
 import { Check } from "react-feather"
@@ -51,26 +51,37 @@ export default function Tag({
   icon: Icon,
   checked,
   onChange,
+  bg,
+  color,
   ...props
 }) {
+  const [internalChecked, set] = useState(checked)
   function handleCheck(e) {
     if (onChange) onChange(e)
+    set(e.target.checked)
   }
   if (!filter)
     return (
-      <StyledTag {...props}>
+      <StyledTag className={className} bg={bg} color={color} {...props}>
         {Icon && <Icon />}
         {children}
       </StyledTag>
     )
   return (
     <StyledTag
-      className={`${className} ${checked && "checked"}`}
+      className={`${className} ${internalChecked ? "checked" : ""}`}
       as="label"
       isFilter={filter}
+      bg={bg}
+      color={color}
     >
-      <input type="checkbox" onChange={handleCheck} checked={checked} {...props} />
-      {checked ? <Check /> : Icon ? <Icon /> : null}
+      <input
+        type="checkbox"
+        onChange={handleCheck}
+        checked={internalChecked}
+        {...props}
+      />
+      {internalChecked ? <Check /> : Icon ? <Icon /> : null}
       {children}
     </StyledTag>
   )

--- a/src/tag/index.js
+++ b/src/tag/index.js
@@ -1,8 +1,29 @@
-import styled from "styled-components"
-import { colors } from "../constants"
+import React, { useState } from "react"
+import styled, { css } from "styled-components"
 import PropTypes from "prop-types"
+import { Check } from "react-feather"
+import { colors } from "../constants"
 
-const Tag = styled.span`
+const filterStyles = css`
+  cursor: pointer;
+  background: ${colors.ui_300};
+  outline: none;
+  transition: 100ms;
+  &:hover {
+    background: ${colors.blue_100};
+  }
+  &.checked {
+    background: ${colors.blue_500};
+    color: ${colors.ui_100};
+  }
+`
+
+const StyledTag = styled.span.attrs({
+  checked: ({ isChecked }) => isChecked,
+  role: ({ filter }) => (filter ? "checkbox" : "row"),
+  tabIndex: 0,
+  "aria-checked": ({ isChecked }) => isChecked
+})`
   display: inline-flex;
   align-items: center;
   font-size: 1.333rem;
@@ -10,20 +31,68 @@ const Tag = styled.span`
   vertical-align: center;
   padding: 0 1rem;
   border-radius: 1rem;
-  background: ${({ bg = colors.gold_500 }) => bg};
-  color: ${({ color = colors.ui_900 }) => color};
+  background: ${({ bg }) => bg};
+  color: ${({ color }) => color};
   svg {
     width: 1.333rem;
     height: 1.333rem;
     margin-right: 0.5rem;
   }
+  ${({ filter }) => filter && filterStyles};
 `
 
-Tag.propTypes = {
-  /** Background color, defaults to gold_500 */
-  bg: PropTypes.string,
-  /** Font color, defaults to ui_900 */
-  color: PropTypes.string
+export default function Tag({
+  children,
+  checked,
+  className,
+  icon: Icon,
+  filter,
+  onChange,
+  ...props
+}) {
+  const [isChecked, setIsChecked] = useState(checked)
+  function handleChange(e) {
+    setIsChecked(!isChecked)
+    onChange(e)
+  }
+  if (!filter)
+    return (
+      <StyledTag className={className} {...props}>
+        {Icon && <Icon />} {children}
+      </StyledTag>
+    )
+  return (
+    <StyledTag
+      className={`${className} ${isChecked && "checked"}`}
+      onClick={handleChange}
+      filter={filter}
+      checked={isChecked}
+      {...props}
+    >
+      {isChecked ? <Check /> : Icon ? <Icon /> : null}
+      {children}
+    </StyledTag>
+  )
 }
 
-export default Tag
+Tag.propTypes = {
+  bg: PropTypes.string,
+  color: PropTypes.string,
+  checked: PropTypes.bool,
+  children: PropTypes.element,
+  className: PropTypes.string,
+  filter: PropTypes.bool,
+  icon: PropTypes.element,
+  onChange: PropTypes.func
+}
+
+Tag.defaultProps = {
+  bg: colors.gold_500,
+  color: colors.ui_900,
+  checked: false,
+  children: null,
+  className: "",
+  filter: false,
+  icon: null,
+  onChange: () => null
+}

--- a/src/tag/tag.test.js
+++ b/src/tag/tag.test.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, fireEvent } from "@testing-library/react"
+import { render, fireEvent, act } from "@testing-library/react"
 import Tag from "src/tag"
 
 describe("<Tag/>", () => {
@@ -7,12 +7,14 @@ describe("<Tag/>", () => {
     const { getByTestId } = render(<Tag data-testid="tag-test-id" />)
     expect(getByTestId("tag-test-id")).not.toBeNull()
   })
-  it("Should render a label if the filter prop is present.", () => {
-    const { getByTestId, container } = render(<Tag filter data-testid="filter-tag" />)
+  it("Should render a label if the filter prop is present.", async () => {
+    const { getByTestId, container } = render(<Tag select data-testid="filter-tag" />)
     const input = getByTestId("filter-tag")
     const element = container.firstChild
     expect(input).not.toBeChecked()
-    fireEvent.click(element)
+    await act(async () => {
+      fireEvent.click(element)
+    })
     expect(input).toBeChecked()
   })
 })

--- a/src/tag/tag.test.js
+++ b/src/tag/tag.test.js
@@ -1,0 +1,18 @@
+import React from "react"
+import { render, fireEvent } from "@testing-library/react"
+import Tag from "src/tag"
+
+describe("<Tag/>", () => {
+  it("Should render a tag component.", () => {
+    const { getByTestId } = render(<Tag data-testid="tag-test-id" />)
+    expect(getByTestId("tag-test-id")).not.toBeNull()
+  })
+  it("Should render a label if the filter prop is present.", () => {
+    const { getByTestId, container } = render(<Tag filter data-testid="filter-tag" />)
+    const input = getByTestId("filter-tag")
+    const element = container.firstChild
+    expect(input).not.toBeChecked()
+    fireEvent.click(element)
+    expect(input).toBeChecked()
+  })
+})


### PR DESCRIPTION
In auditing the listings stepper we found that there is no explicit pattern with our system for inline checkboxes.

This PR updates the tag component to consume a `select` prop that changes the underlying tag component to include a checkbox and control its own `checked` state.