### PR TITLE
Update Tooltip API

### DIFF
--- a/src/tooltip/doc.mdx
+++ b/src/tooltip/doc.mdx
@@ -29,14 +29,10 @@ Tooltips offer greater context to an action or element on the page. Tooltips sho
 
 ### Props
 
+#### Tooltip
+
 <Prop name="id" type="string">
   ID needed for accesability
-</Prop>
-<Prop name="content" type="element">
-  The internal content of the tooltip.
-</Prop>
-<Prop name="targetRef" type="ref">
-  Reference to target dom node that triggers the visibly hidden content.
 </Prop>
 
 ## Usage

--- a/src/tooltip/doc.mdx
+++ b/src/tooltip/doc.mdx
@@ -8,8 +8,7 @@ import { Fragment, useRef } from "react"
 import Playground from "utils/playground"
 import Status from "utils/status"
 import Prop from "utils/prop"
-import Popover from "src/popover"
-import Tooltip from "src/tooltip"
+import Tooltip, { TooltipTarget, TooltipContent } from "src/tooltip"
 import Button from "src/button"
 
 # Tooltips
@@ -44,22 +43,14 @@ Tooltips offer greater context to an action or element on the page. Tooltips sho
 
 <Playground>
   {() => {
-    const buttonRef = useRef()
-    const TooltipContent = props => {
-      return (
-        <div>
-          <h3>Look at this button</h3>
-          <p>
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. A quisquam suscipit
-            hic nisi cum dolorem quasi, nesciunt, animi assumenda enim autem consectetur,
-            tenetur eius excepturi eum asperiores explicabo eligendi tempora!
-          </p>
-        </div>
-      )
-    }
     return (
-      <Tooltip targetRef={buttonRef} id="button-target" content={<TooltipContent/>}>
-        <Button ref={buttonRef}>Hello World</Button>
+      <Tooltip id="button-target">
+        <TooltipTarget>
+          <Button>Hello World</Button>
+        </TooltipTarget>
+        <TooltipContent>
+          <p>Hello World</p>
+        </TooltipContent>
       </Tooltip>
     )
   }}

--- a/src/tooltip/doc.mdx
+++ b/src/tooltip/doc.mdx
@@ -13,7 +13,7 @@ import Button from "src/button"
 
 # Tooltips
 
-<Status status="beta" />
+<Status status="production" />
 
 ## Installation
 

--- a/src/tooltip/index.js
+++ b/src/tooltip/index.js
@@ -5,7 +5,8 @@ import React, {
   createContext,
   useReducer,
   useRef,
-  useContext
+  useContext,
+  Children
 } from "react"
 import styled from "styled-components"
 import { colors } from "src/constants"
@@ -55,23 +56,25 @@ function Target({ children, ...props }, ref) {
     dispatch
   } = useContext(TooltipContext)
   useImperativeHandle(ref, () => ({ ...targetRef }))
+  const child = Children.only(children)
+  const { onBlur, onFocus, onMouseEnter, onMouseLeave } = child.props
   function handleToggle() {
     dispatch({ type: OPEN_TOOLTIP })
   }
   function handleClose() {
     dispatch({ type: CLOSE_TOOLTIP })
   }
-  return cloneElement(children, {
+  return cloneElement(child, {
     ...props,
     ref: targetRef,
     id,
     type: "button",
     "aria-haspopup": "menu",
     "aria-expanded": isOpen,
-    onFocus: wrapEvent(children.props.onFocus, handleToggle),
-    onBlur: wrapEvent(children.props.onBlur, handleClose),
-    onMouseEnter: wrapEvent(children.props.onMouseEnter, handleToggle),
-    onMouseLeave: wrapEvent(children.props.onMouseLeave, handleClose)
+    onFocus: wrapEvent(onFocus, handleToggle),
+    onBlur: wrapEvent(onBlur, handleClose),
+    onMouseEnter: wrapEvent(onMouseEnter, handleToggle),
+    onMouseLeave: wrapEvent(onMouseLeave, handleClose)
   })
 }
 
@@ -89,6 +92,7 @@ const StyledTooltip = styled.aside`
 
 function Content({ children, ...props }, ref) {
   const {
+    id,
     state: { isOpen },
     tooltipRef,
     popoverRef,
@@ -97,7 +101,13 @@ function Content({ children, ...props }, ref) {
   useImperativeHandle(ref, () => ({ ...tooltipRef }))
   return isOpen ? (
     <Popover targetRef={targetRef} ref={popoverRef}>
-      <StyledTooltip {...props} ref={tooltipRef}>
+      <StyledTooltip
+        {...props}
+        ref={tooltipRef}
+        role="tooltip"
+        id={id}
+        aria-hidden={!isOpen}
+      >
         {children}
       </StyledTooltip>
     </Popover>

--- a/src/tooltip/index.js
+++ b/src/tooltip/index.js
@@ -1,16 +1,83 @@
 import React, {
-  Fragment,
   cloneElement,
-  useState,
   forwardRef,
-  Children,
-  useImperativeHandle
+  useImperativeHandle,
+  createContext,
+  useReducer,
+  useRef,
+  useContext
 } from "react"
 import styled from "styled-components"
 import { colors } from "src/constants"
 import Popover from "src/popover"
 
-const StyledTooltip = styled(Popover)`
+const TooltipContext = createContext()
+
+const OPEN_TOOLTIP = "@rent_avail/tooltip/open_tooltip"
+const CLOSE_TOOLTIP = "@rent_avail/tooltip/close_tooltip"
+
+const initialState = {
+  isOpen: false
+}
+
+function tooltipReducer(state, action) {
+  switch (action.type) {
+    case OPEN_TOOLTIP:
+      return { ...state, isOpen: true }
+    case CLOSE_TOOLTIP:
+      return { ...state, isOpen: false }
+    default:
+      throw Error("Must dispatch a known action from Tooltip Reducer.")
+  }
+}
+
+function Tooltip({ children, id }) {
+  const [state, dispatch] = useReducer(tooltipReducer, initialState)
+  const targetRef = useRef()
+  const tooltipRef = useRef()
+  const popoverRef = useRef()
+  const context = { state, dispatch, id, targetRef, tooltipRef, popoverRef }
+  return <TooltipContext.Provider value={context}>{children}</TooltipContext.Provider>
+}
+
+function wrapEvent(first, second) {
+  return event => {
+    if (first) first(event)
+    if (!event.defaultPrevented) second(event)
+  }
+}
+
+function Target({ children, ...props }, ref) {
+  const {
+    id,
+    targetRef,
+    state: { isOpen },
+    dispatch
+  } = useContext(TooltipContext)
+  useImperativeHandle(ref, () => ({ ...targetRef }))
+  function handleToggle() {
+    dispatch({ type: OPEN_TOOLTIP })
+  }
+  function handleClose() {
+    dispatch({ type: CLOSE_TOOLTIP })
+  }
+  return cloneElement(children, {
+    ...props,
+    ref: targetRef,
+    id,
+    type: "button",
+    "aria-haspopup": "menu",
+    "aria-expanded": isOpen,
+    onFocus: wrapEvent(children.props.onFocus, handleToggle),
+    onBlur: wrapEvent(children.props.onBlur, handleClose),
+    onMouseEnter: wrapEvent(children.props.onMouseEnter, handleToggle),
+    onMouseLeave: wrapEvent(children.props.onMouseLeave, handleClose)
+  })
+}
+
+const TooltipTarget = forwardRef(Target)
+
+const StyledTooltip = styled.aside`
   min-width: 10rem;
   max-width: 40rem;
   background: ${colors.blue_700};
@@ -20,50 +87,23 @@ const StyledTooltip = styled(Popover)`
   margin-right: 2rem;
 `
 
-function Tooltip({ children, targetRef, content = null, id, ...props }, ref) {
-  const [isOpen, setIsOpen] = useState(false)
-  const child = Children.only(children)
-  function onFocus(e) {
-    if (child.props.onFocus) child.props.onFocus(e)
-    setIsOpen(true)
-  }
-  function onBlur(e) {
-    if (child.props.onBlur) child.props.onBlur(e)
-    setIsOpen(false)
-  }
-  function onMouseEnter(e) {
-    if (child.props.onMouseEnter) child.props.onMouseEnter(e)
-    setIsOpen(true)
-  }
-  function onMouseLeave(e) {
-    if (child.props.onMouseLeave) child.props.onMouseLeave(e)
-    setIsOpen(false)
-  }
-  useImperativeHandle(ref, () => ({ ...targetRef }))
-  return (
-    <Fragment>
-      {cloneElement(child, {
-        "aria-labelledby": id,
-        onFocus,
-        onBlur,
-        onMouseEnter,
-        onMouseLeave
-      })}
-      {isOpen && (
-        <StyledTooltip
-          {...props}
-          targetRef={targetRef}
-          ref={ref}
-          role="tooltip"
-          tabIndex="0"
-          aria-hidden={!isOpen}
-          id={id}
-        >
-          {content}
-        </StyledTooltip>
-      )}
-    </Fragment>
-  )
+function Content({ children, ...props }, ref) {
+  const {
+    state: { isOpen },
+    tooltipRef,
+    popoverRef,
+    targetRef
+  } = useContext(TooltipContext)
+  useImperativeHandle(ref, () => ({ ...tooltipRef }))
+  return isOpen ? (
+    <Popover targetRef={targetRef} ref={popoverRef}>
+      <StyledTooltip {...props} ref={tooltipRef}>
+        {children}
+      </StyledTooltip>
+    </Popover>
+  ) : null
 }
 
-export default forwardRef(Tooltip)
+const TooltipContent = forwardRef(Content)
+
+export { Tooltip as default, TooltipTarget, TooltipContent }

--- a/src/tooltip/tooltip.test.js
+++ b/src/tooltip/tooltip.test.js
@@ -1,52 +1,24 @@
-import React, { useRef, Fragment } from "react"
-import Tooltip from "src/tooltip"
+import React from "react"
+import Tooltip, { TooltipTarget, TooltipContent } from "src/tooltip"
 import Button from "src/button"
-import { render, fireEvent } from "@testing-library/react"
+import { render } from "@testing-library/react"
 
 describe("<Tooltip />", () => {
-  // function Wrapper() {
-  //   const buttonRef = useRef()
-  //   return (
-  //     <Fragment>
-  //       <Button ref={buttonRef}>Hello World</Button>
-  //       <Tooltip target={buttonRef} id="button-target" data-testid="tooltip-id" />
-  //     </Fragment>
-  //   )
-  // }
-  // it("Should render a tooltip without crashing", () => {
-  //   const { getByTestId } = render(<Wrapper />)
-  //   const tooltip = getByTestId("tooltip-id")
-  //   expect(tooltip).toBeInTheDocument()
-  // })
-  // it("Should not display a tooltip on initial render", () => {
-  //   const { getByTestId } = render(<Wrapper />)
-  //   const tooltip = getByTestId("tooltip-id")
-  //   expect(tooltip).toHaveStyle(`
-  //     display: none;
-  //   `)
-  // })
-  // it("Should change it's display when focused", () => {
-  //   const { getByTestId, getByText, debug } = render(<Wrapper />)
-  //   const tooltip = getByTestId("tooltip-id")
-  //   const button = getByText(/Hello World/)
-  //   fireEvent.focus(button)
-  //   debug()
-  //   expect(tooltip).toHaveStyle(`
-  //     display: block;
-  //   `)
-  // })
   it("Should render a tooltip without crashing", () => {
     const Wrapper = () => {
-      const buttonRef = useRef()
       return (
-        <Tooltip targetRef={buttonRef} content="This is a tooltip.">
-          <Button data-testid="tooltip-target" ref={buttonRef}>
-            hello world
-          </Button>
+        <Tooltip content="This is a tooltip.">
+          <TooltipTarget>
+            <Button data-testid="tooltip-target">hello world</Button>
+          </TooltipTarget>
+          <TooltipContent data-testid="tooltip-content">
+            <p>Look, a tooltip.</p>
+          </TooltipContent>
         </Tooltip>
       )
     }
-    const { getByTestId } = render(<Wrapper />)
+    const { getByTestId, queryByTestId } = render(<Wrapper />)
     expect(getByTestId("tooltip-target")).toBeInTheDocument()
+    expect(queryByTestId("tooltip-content")).toBeNull()
   })
 })


### PR DESCRIPTION
Remove props in favor of child components.

## New API
```js
return (
  <Tooltip>
    <TooltipTarget>
      <SomeComponent />
    </TooltipTarget>
    <TooltipContent>
      Look, I'm visibly hidden!
    </TooltipContent>
  </Tooltip>
)
```