### PR TITLE
Update Remove Method

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -58,7 +58,7 @@ export function usePortal() {
   useEffect(() => {
     document.body.appendChild(rootElement.current)
     return () => {
-      rootElement.current.remove()
+      document.body.removeChild(rootElement.current)
     }
   }, [rootElement.current])
   return rootElement.current


### PR DESCRIPTION
HoneyBadger was sending an error on IE for the usePortal hook: https://app.honeybadger.io/projects/33225/faults/60197634

This DOM API is not supported on IE: https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove

Move to this supported API: https://developer.mozilla.org/en-US/docs/Web/API/Node/removeChild