### PR TITLE
v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/elements",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/elements",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "A suite of elements for the consistent and responsive UI",
   "keywords": [
     "ui",

--- a/src/checkbox/doc.mdx
+++ b/src/checkbox/doc.mdx
@@ -4,6 +4,7 @@ route: /components/checkbox
 menu: Components
 ---
 
+import { useState } from "react"
 import Playground from "utils/playground"
 import Status from "utils/status"
 import Prop from "utils/prop"
@@ -37,7 +38,7 @@ Checkboxes are user selection tools when multiple options can be chosen at the s
 
 <Playground>
   <Checkbox />
-  <Checkbox checked />
+  <Checkbox defaultChecked />
   <Checkbox />
 </Playground>
 
@@ -52,6 +53,33 @@ A checkbox's children will render as the lable to the right of the element. Chec
   <Checkbox>Allow Parrots</Checkbox>
 </Playground>
 
-#### TODO
+### Controlled input
 
-1. Build an indeterminate state for the checkbox
+<Playground>
+  {() => {
+    const [checked, set] = useState(false)
+    function handleChange(event) {
+      set(event.target.checked)
+    }
+    return (
+      <Checkbox checked={checked} onChange={handleChange}>
+        I am {checked ? "checked" : "not checked"}
+      </Checkbox>
+    )
+  }}
+</Playground>
+
+## Extension
+
+### `.checked`
+
+The checkbox component will have a checked class when the input is checked
+
+```js
+const CustomChecked = styled(Checkbox)`
+  background: ${colors.ui_300};
+  &.checked {
+    background: ${colors.blue_100};
+  }
+`
+```

--- a/src/checkbox/index.js
+++ b/src/checkbox/index.js
@@ -1,11 +1,11 @@
-import React, { forwardRef } from "react"
+import React, { forwardRef, useState, useReducer } from "react"
 import styled from "styled-components"
 import { colors } from "src/constants"
 
 const StyledCheckbox = styled.label`
   position: relative;
   display: inline-flex;
-  cursor: ${({ isDisabled }) => (isDisabled ? "not-allowed" : "pointer")};
+  cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
   input {
     opacity: 0;
     width: 0;
@@ -21,22 +21,17 @@ const StyledCheckbox = styled.label`
     display: flex;
     align-items: center;
     justify-content: center;
+    stroke-dasharray: 24;
+    stroke-dashoffset: 24;
     transition: 300ms;
-    svg {
-      stroke-dasharray: 24;
-      stroke-dashoffset: 24;
-      transition: 300ms;
-      color: ${colors.ui_100};
-      will-change: stroke-dashoffset;
-    }
+    color: ${colors.ui_100};
+    will-change: stroke-dashoffset;
   }
 
   input:checked ~ .input__target {
     border: 2px solid ${colors.blue_500};
     background: ${colors.blue_500};
-    svg {
-      stroke-dashoffset: 0;
-    }
+    stroke-dashoffset: 0;
   }
 
   input:disabled ~ .input__target {
@@ -48,12 +43,39 @@ const StyledCheckbox = styled.label`
   }
 `
 
-const Checkbox = forwardRef(({ children, className, disabled, ...props }, ref) => (
-  <StyledCheckbox className={className} isDisabled={disabled}>
-    <input type="checkbox" ref={ref} disabled={disabled} {...props} />
-    <div className="input__target">
+function Checkbox(
+  {
+    children,
+    className = "",
+    disabled,
+    onChange = null,
+    defaultChecked = false,
+    ...props
+  },
+  ref
+) {
+  const reducer = (state, action) => ({ ...state, ...action })
+  const [{ checked }, dispatch] = useReducer(reducer, { checked: defaultChecked })
+  function handleChange(event) {
+    if (onChange) onChange(event)
+    dispatch({ checked: event.target.checked })
+  }
+  return (
+    <StyledCheckbox
+      disabled={disabled}
+      className={`${checked ? "checked" : ""} ${className}`}
+    >
+      <input
+        {...props}
+        type="checkbox"
+        ref={ref}
+        onChange={handleChange}
+        disabled={disabled}
+        checked={checked}
+      />
       <svg
-        xmlns="http://www.w3.org/2000/svg"
+        role="button"
+        className="input__target"
         width="24"
         height="24"
         viewBox="0 0 24 24"
@@ -65,9 +87,9 @@ const Checkbox = forwardRef(({ children, className, disabled, ...props }, ref) =
       >
         <polyline points="20 6 9 17 4 12" />
       </svg>
-    </div>
-    {children && <span className="label">{children}</span>}
-  </StyledCheckbox>
-))
+      {children && <span className="label">{children}</span>}
+    </StyledCheckbox>
+  )
+}
 
-export default Checkbox
+export default forwardRef(Checkbox)

--- a/src/constants.js
+++ b/src/constants.js
@@ -44,7 +44,7 @@ export function throttle(fn, ms) {
     fn.apply()
   }
   function clear() {
-    timeout == undefined ? null : clearTimeout(timeout)
+    return timeout === "undefined" ? null : clearTimeout(timeout)
   }
   if (fn !== undefined && ms !== undefined) {
     timeout = setTimeout(exec, ms)
@@ -52,7 +52,14 @@ export function throttle(fn, ms) {
     console.error("callback function and the timeout must be supplied")
   }
   // API to clear the timeout
-  throttle.clearTimeout = function() {
-    clear()
+  throttle.clearTimeout = clear()
+}
+
+export function wrapEvent(first, second) {
+  return event => {
+    if (first) first(event)
+    if (!event.defaultPrevented) return second(event)
   }
 }
+
+export function noop() {}

--- a/src/grid/doc.mdx
+++ b/src/grid/doc.mdx
@@ -28,33 +28,23 @@ Grids are used to build consistent, responsive layouts. The `<Grid/>` component 
 
 ### Grid Props
 
-<Prop name="column" type="number" defaultValue="12">
-  Optional override on the number of columns the grid contains.
+<Prop name="theme" type="object" defaultValue="themeObject">
+  Optional override on columns, gap, and break points.
 </Prop>
 
-<Prop name="gap" type="string" defaultValue="2rem">
-  Optional override on the gap inbetween columns and rows.
-</Prop>
-
-<Prop name="xsmBreak" type="string" defaultValue="40rem">
-  Optional override for the extra small breakpoint.
-</Prop>
-
-<Prop name="smBreak" type="string" defaultValue="60rem">
-  Optional override for the small breakpoint.
-</Prop>
-
-<Prop name="mdBreak" type="string" defaultValue="80rem">
-  Optional override for the medium breakpoint.
-</Prop>
-
-<Prop name="lgBreak" type="string" defaultValue="100rem">
-  Optional override for the large breakpoint.
-</Prop>
-
-<Prop name="xlgBreak" type="string" defaultValue="120rem">
-  Optional override for the extra large breakpoint.
-</Prop>
+```js
+themeObject = {
+  columns: 12,
+  gap: 2,
+  breakPoints: {
+    xsm: 40,
+    sm: 60,
+    md: 80,
+    lg: 100,
+    xlg: 120
+  }
+}
+```
 
 ### Col Props
 

--- a/src/grid/index.js
+++ b/src/grid/index.js
@@ -1,64 +1,6 @@
-import React, { forwardRef } from "react"
+import React, { forwardRef, Children, cloneElement } from "react"
 import styled from "styled-components"
-import PropTypes from "prop-types"
-
-const StyledGrid = styled.section`
-  display: grid;
-  grid-template-columns: repeat(${({ columns }) => columns}, 1fr);
-  grid-gap: ${({ gap }) => gap};
-`
-
-export const Grid = forwardRef(
-  (
-    {
-      children,
-      xsmBreak = "40rem",
-      smBreak = "60rem",
-      mdBreak = "80rem",
-      lgBreak = "100rem",
-      xlgBreak = "120rem",
-      ...props
-    },
-    ref
-  ) => {
-    const renderChildren = () =>
-      React.Children.map(children, child =>
-        React.cloneElement(child, {
-          xsmBreak,
-          smBreak,
-          mdBreak,
-          lgBreak,
-          xlgBreak
-        })
-      )
-    return (
-      <StyledGrid ref={ref} {...props}>
-        {renderChildren()}
-      </StyledGrid>
-    )
-  }
-)
-
-Grid.propTypes = {
-  columns: PropTypes.number,
-  gap: PropTypes.string,
-  xsmBreak: PropTypes.string,
-  smBreak: PropTypes.string,
-  mdBreak: PropTypes.string,
-  lgBreak: PropTypes.string,
-  xlgBreak: PropTypes.string,
-  children: PropTypes.node.isRequired
-}
-
-Grid.defaultProps = {
-  xsmBreak: "40rem",
-  smBreak: "60rem",
-  mdBreak: "80rem",
-  lgBreak: "100rem",
-  xlgBreak: "120rem",
-  gap: "2rem",
-  columns: 12
-}
+import p from "prop-types"
 
 function getIndex(arr, index) {
   return arr[index] ? arr[index] : arr[arr.length - 1]
@@ -69,40 +11,72 @@ function getOffset(offset, index) {
   return start === "auto" ? "auto" : start + 1
 }
 
-export const Col = styled.div`
-  grid-column: ${({ offset }) => `${getOffset(offset, 0)} /`} span
-    ${({ span }) => getIndex(span, 0)};
-  grid-row: ${({ offsetRow }) => `${getOffset(offsetRow, 0)} /`} span
-    ${({ spanRow }) => getIndex(spanRow, 0)};
-  @media (min-width: ${({ xsmBreak }) => xsmBreak}) {
-    grid-column: ${({ offset }) => `${getOffset(offset, 1)} /`} span
-      ${({ span }) => getIndex(span, 1)};
-    grid-row: ${({ offsetRow }) => `${getOffset(offsetRow, 1)} /`} span
-      ${({ spanRow }) => getIndex(spanRow, 1)};
+const StyledGrid = styled.section`
+  display: grid;
+  grid-template-columns: repeat(${({ theme: { columns } }) => columns}, 1fr);
+  grid-gap: ${({ theme: { gap } }) => gap}rem;
+`
+
+function GridContainer(
+  {
+    children,
+    theme = {
+      columns: 12,
+      gap: 2,
+      breakPoints: {
+        xsm: 40,
+        sm: 60,
+        md: 80,
+        lg: 100,
+        xlg: 120
+      }
+    },
+    ...props
+  },
+  ref
+) {
+  const childProps = { ...theme.breakPoints }
+  return (
+    <StyledGrid ref={ref} theme={theme} {...props}>
+      {Children.map(children, child => cloneElement(child, childProps))}
+    </StyledGrid>
+  )
+}
+
+const Col = styled.div`
+  ${({ offset, span, offsetRow, spanRow }) => `
+    grid-column: ${getOffset(offset, 0)} / span ${getIndex(span, 0)};
+    grid-row: ${getOffset(offsetRow, 0)} / span ${getIndex(spanRow, 0)};
+  `}
+  @media (min-width: ${({ xsm }) => xsm}rem) {
+    ${({ offset, span, offsetRow, spanRow }) => `
+      grid-column: ${getOffset(offset, 1)} / span ${getIndex(span, 1)};
+      grid-row: ${getOffset(offsetRow, 1)} / span ${getIndex(spanRow, 1)};
+    `}
   }
-  @media (min-width: ${({ smBreak }) => smBreak}) {
-    grid-column: ${({ offset }) => `${getOffset(offset, 2)} /`} span
-      ${({ span }) => getIndex(span, 2)};
-    grid-row: ${({ offsetRow }) => `${getOffset(offsetRow, 2)} /`} span
-      ${({ spanRow }) => getIndex(spanRow, 2)};
+  @media (min-width: ${({ sm }) => sm}rem) {
+    ${({ offset, span, offsetRow, spanRow }) => `
+      grid-column: ${getOffset(offset, 2)} / span ${getIndex(span, 2)};
+      grid-row: ${getOffset(offsetRow, 2)} / span ${getIndex(spanRow, 2)};
+    `}
   }
-  @media (min-width: ${({ mdBreak }) => mdBreak}) {
-    grid-column: ${({ offset }) => `${getOffset(offset, 3)} /`} span
-      ${({ span }) => getIndex(span, 3)};
-    grid-row: ${({ offsetRow }) => `${getOffset(offsetRow, 3)} /`} span
-      ${({ spanRow }) => getIndex(spanRow, 3)};
+  @media (min-width: ${({ md }) => md}rem) {
+    ${({ offset, span, offsetRow, spanRow }) => `
+      grid-column: ${getOffset(offset, 3)} / span ${getIndex(span, 3)};
+      grid-row: ${getOffset(offsetRow, 3)} / span ${getIndex(spanRow, 3)};
+    `}
   }
-  @media (min-width: ${({ lgBreak }) => lgBreak}) {
-    grid-column: ${({ offset }) => `${getOffset(offset, 4)} /`} span
-      ${({ span }) => getIndex(span, 4)};
-    grid-row: ${({ offsetRow }) => `${getOffset(offsetRow, 4)} /`} span
-      ${({ spanRow }) => getIndex(spanRow, 4)};
+  @media (min-width: ${({ lg }) => lg}rem) {
+    ${({ offset, span, offsetRow, spanRow }) => `
+      grid-column: ${getOffset(offset, 4)} / span ${getIndex(span, 4)};
+      grid-row: ${getOffset(offsetRow, 4)} / span ${getIndex(spanRow, 4)};
+    `}
   }
-  @media (min-width: ${({ xlgBreak }) => xlgBreak}) {
-    grid-column: ${({ offset }) => `${getOffset(offset, 5)} /`} span
-      ${({ span }) => getIndex(span, 5)};
-    grid-row: ${({ offsetRow }) => `${getOffset(offsetRow, 5)} /`} span
-      ${({ spanRow }) => getIndex(spanRow, 5)};
+  @media (min-width: ${({ xlg }) => xlg}rem) {
+    ${({ offset, span, offsetRow, spanRow }) => `
+      grid-column: ${getOffset(offset, 5)} / span ${getIndex(span, 5)};
+      grid-row: ${getOffset(offsetRow, 5)} / span ${getIndex(spanRow, 5)};
+    `}
   }
 `
 
@@ -114,8 +88,12 @@ Col.defaultProps = {
 }
 
 Col.propTypes = {
-  span: PropTypes.arrayOf(PropTypes.number),
-  spanRow: PropTypes.arrayOf(PropTypes.number),
-  offset: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
-  offsetRow: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number]))
+  span: p.arrayOf(p.number),
+  spanRow: p.arrayOf(p.number),
+  offset: p.arrayOf(p.oneOfType([p.string, p.number])),
+  offsetRow: p.arrayOf(p.oneOfType([p.string, p.number]))
 }
+
+const Grid = forwardRef(GridContainer)
+
+export { Grid, Col }

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -13,6 +13,20 @@ export function useRect(ref) {
   return rect
 }
 
+export function useWindowResize(ref) {
+  const [size, setSize] = useState({})
+  useEffect(() => {
+    function handleResize() {
+      if (!ref.current) return false
+      setSize(ref.current.getBoundingClientRect())
+    }
+    handleResize()
+    window.addEventListener("resize", handleResize)
+    return () => window.removeEventListener("resize", handleResize)
+  }, [])
+  return size
+}
+
 export function useResize() {
   const ref = useRef(null)
   const [bounds, set] = useState({

--- a/src/menu/index.js
+++ b/src/menu/index.js
@@ -69,7 +69,7 @@ function Target({ children, style, ...rest }, ref) {
   } = useContext(MenuContext)
   const child = Children.only(children)
   useImperativeHandle(ref, () => ({ ...targetRef }))
-  function handleMouseDown(e) {
+  function handleMouseDown() {
     dispatch({ type: TOGGLE_MENU })
   }
   return cloneElement(child, {

--- a/src/modal/doc.mdx
+++ b/src/modal/doc.mdx
@@ -118,3 +118,7 @@ Modals are ways to ask a user for confirmation or to take action without losing 
     )
   }}
 </Playground>
+
+## Extending
+
+The modal body is a card with the class `.modal__body`. The modal itself is the container or "scrim" that overlays the rest of the viewport.

--- a/src/popover/index.js
+++ b/src/popover/index.js
@@ -1,6 +1,12 @@
-import React, { useRef, forwardRef, useImperativeHandle } from "react"
+import React, {
+  useRef,
+  forwardRef,
+  useImperativeHandle,
+  useState,
+  useEffect
+} from "react"
 import { createPortal } from "react-dom"
-import { usePortal, useRect } from "src/hooks"
+import { usePortal, useWindowResize } from "src/hooks"
 
 function getCollisions(popoverRect, targetRect, offsetLeft = 0, offsetBottom = 0) {
   const collisions = {
@@ -14,7 +20,7 @@ function getCollisions(popoverRect, targetRect, offsetLeft = 0, offsetBottom = 0
   return { right, up }
 }
 
-function getPosition(popoverRect, targetRect) {
+function calculate(popoverRect, targetRect) {
   if (!popoverRect || !targetRect) return {}
   const { right, up } = getCollisions(popoverRect, targetRect)
   return {
@@ -31,18 +37,21 @@ function getPosition(popoverRect, targetRect) {
   }
 }
 
-function PopOver({ targetRef, position = getPosition, style, children, ...rest }, ref) {
+function PopOver({ targetRef, getPosition = calculate, style, children, ...rest }, ref) {
   const portalTarget = usePortal()
   const popoverRef = useRef(null)
-  const popoverRect = useRect(popoverRef)
-  const targetRect = useRect(targetRef)
+  const popoverRect = useWindowResize(popoverRef)
+  const targetRect = useWindowResize(targetRef)
+  const [position, setPosition] = useState({})
   useImperativeHandle(ref, () => ({ ...popoverRef.current }))
-  const positionStyles = position(popoverRect, targetRect)
+  useEffect(() => {
+    setPosition(getPosition(popoverRect, targetRect))
+  }, [targetRect])
   return createPortal(
     <aside
       {...rest}
       ref={popoverRef}
-      style={{ ...style, position: "absolute", ...positionStyles }}
+      style={{ ...style, position: "absolute", ...position }}
     >
       {children}
     </aside>,

--- a/src/radio/doc.mdx
+++ b/src/radio/doc.mdx
@@ -31,6 +31,11 @@ Radio buttons are used to select one option from a set. Use radio buttons when i
   Controls the checked nature of the radio button to give the user feedback.
 </Prop>
 
+<Prop name="value" type="string">
+  Value of the radio input.
+</Prop>
+
+
 ## RadioGroup Anatomy
 
 ### Props
@@ -44,8 +49,8 @@ Radio buttons are used to select one option from a set. Use radio buttons when i
 ### Radio
 
 <Playground>
-  <Radio checked />
   <Radio />
+  <Radio value="delivery" />
 </Playground>
 
 ### Radio Group
@@ -54,11 +59,11 @@ To easily group buttons into usable forms, use the `RadioGroup` component
 
 <Playground column>
   <RadioGroup inline>
-    <Radio name="user-type" />
-    <Radio name="user-type" />
+    <Radio name="user-type" value="landlord" />
+    <Radio name="user-type" value="tenant" />
   </RadioGroup>
   <RadioGroup style={{ marginTop: "2rem" }}>
-    <Radio name="payment-type" />
-    <Radio name="payment-type" />
+    <Radio name="payment-type" value="ach" />
+    <Radio name="payment-type" value="debit" />
   </RadioGroup>
 </Playground>

--- a/src/radio/index.js
+++ b/src/radio/index.js
@@ -1,11 +1,11 @@
-import React, { forwardRef } from "react"
+import React, { forwardRef, useReducer } from "react"
 import styled from "styled-components"
 import { colors } from "../constants"
 
-const StyledRadioButton = styled.label`
+const StyledRadio = styled.label`
   position: relative;
   display: inline-flex;
-  cursor: ${({ isDisabled }) => (isDisabled ? "not-allowed" : "cursor")};
+  cursor: ${({ disabled }) => (disabled ? "not-allowed" : "cursor")};
   input[type="radio"] {
     width: 0;
     height: 0;
@@ -13,6 +13,7 @@ const StyledRadioButton = styled.label`
     opacity: 0;
   }
   .radio__target {
+    all: unset;
     width: 2rem;
     height: 2rem;
     border-radius: 50%;
@@ -44,25 +45,27 @@ const StyledRadioButton = styled.label`
   input:disabled ~ .radio__target {
     border: 2px solid ${colors.ui_300};
   }
-  .label {
+  .radio__label {
     margin-left: 1rem;
   }
 `
 
-export default forwardRef(({ children, className, disabled, ...props }, ref) => (
-  <StyledRadioButton className={className} isDisabled={disabled}>
-    <input type="radio" {...props} ref={ref} disabled={disabled} />
-    <div className="radio__target" />
-    {children && <span className="label">{children}</span>}
-  </StyledRadioButton>
-))
-
 export const RadioGroup = styled.fieldset`
-  border: none;
-  padding: 0;
-  margin: 0;
+  all: unset;
   display: ${({ inline }) => (inline ? "block" : "flex")};
   > *:not(:last-child) {
     ${({ inline }) => (inline ? `margin-right: 2rem;` : `margin-bottom: 2rem;`)}
   }
 `
+
+function Radio({ children = null, className = "", disabled = false, ...props }, ref) {
+  return (
+    <StyledRadio className={className} disabled={disabled}>
+      <input {...props} ref={ref} type="radio" disabled={disabled} />
+      <div role="button" className="radio__target" />
+      {children && <span className="radio__label">{children}</span>}
+    </StyledRadio>
+  )
+}
+
+export default forwardRef(Radio)

--- a/src/select/doc.mdx
+++ b/src/select/doc.mdx
@@ -1,0 +1,99 @@
+---
+name: Select Inputs
+route: /components/select
+menu: Components
+---
+
+import {Fragment, useState} from "react"
+import Prop from "utils/prop"
+import Status from "utils/status"
+import Playground from "utils/playground"
+import Select, { SelectInput, SelectList, SelectItem } from "src/select"
+
+# Select Inputs
+
+<Status status="beta" />
+
+## Installation
+
+```js
+import Select, { SelectInput, SelectList, SelectItem } from "src/select"
+```
+
+## Description
+
+Select inputs display the currently selected option above a menu that lets the user choose from a list of pre-defined values.
+
+## Anatomy
+
+1. Search Input
+1. Dropdown List
+1. Dropdown Indicator
+
+### Props
+
+#### Select
+
+<Prop name="id" type="string">
+  Unique identifier for the select group.
+</Prop>
+
+<Prop name="onSelect" type="function">
+  Fires when the user selects an item from the dropdown list.
+</Prop>
+
+#### Select Input
+
+<Prop name="label" type="string">
+  Label for the text input of the select box.
+</Prop>
+
+<Prop name="search" type="boolean" defaultValue="true">
+  Optional toggle allowing users to search options of the select input.
+</Prop>
+
+#### Select Item
+
+<Prop name="value" type="string">
+  This will override the input when the user selects an option.
+</Prop>
+
+<Prop name="label" type="string">
+  This will be used to filter item results instead of value if used.
+</Prop>
+
+<Prop name="children" type="element">
+  This can be any react element equivalent.
+</Prop>
+
+## Usage
+
+<Playground column>
+  {() => {
+    const options = [
+      { label: "Alabama", value: "AL" },
+      { label: "Alaska", value: "AK" },
+      { label: "Arizona", value: "AZ" },
+      { label: "Arkansas", value: "AR" },
+      { label: "California", value: "CA" },
+      { label: "Colorado", value: "CO" },
+      { label: "Connecticut", value: "CT" }
+    ]
+    const [state, setState] = useState("")
+    return (
+      <Fragment>
+        <p>Selected State: {state}</p>
+        <Select id="select-id" onSelect={value => setState(value)}>
+        <SelectInput label="Choose a state" />
+        <SelectList>
+          {options.map(({ label, value }) => (
+            <SelectItem key={value} value={value} label={label}>
+              {label}
+            </SelectItem>
+          ))}
+        </SelectList>
+      </Select>
+      </Fragment>
+    )
+  }}
+</Playground>

--- a/src/select/index.js
+++ b/src/select/index.js
@@ -1,19 +1,273 @@
-import React, { forwardRef } from "react"
-import styled from "styled-components"
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  createContext,
+  useReducer,
+  useContext,
+  useEffect,
+  useState
+} from "react"
+import styled, { css } from "styled-components"
+import Popover from "src/popover"
+import Card from "src/card"
+import { useWindowResize } from "src/hooks"
+import { colors, wrapEvent, noop } from "src/constants"
+import { ChevronDown } from "react-feather"
 
-const StyledSelect = styled.label`
-  position: relative;
-  display: inline-flex;
+const SelectContext = createContext()
+
+const types = {
+  OPEN_LIST: "@rent_avail/elements/select/open_list",
+  CLOSE_LIST: "@rent_avail/elements/select/close_list",
+  UPDATE_WIDTH: "@rent_avail/elements/select/update_width",
+  UPDATE_INPUT: "@rent_avail/elements/select/update_input",
+  SET_VALUE: "@rent_avail/elements/select/set_value"
+}
+
+const initialState = {
+  selectValue: "",
+  inputValue: "",
+  width: 120,
+  isOpen: false
+}
+
+function selectReducer(state, action) {
+  switch (action.type) {
+    case types.OPEN_LIST:
+      return { ...state, isOpen: true }
+    case types.CLOSE_LIST:
+      return { ...state, isOpen: false, inputValue: "" }
+    case types.UPDATE_WIDTH:
+      return { ...state, width: action.width }
+    case types.UPDATE_INPUT:
+      return { ...state, inputValue: action.value, selectValue: "" }
+    case types.SET_VALUE:
+      return { ...state, isOpen: false, selectValue: action.value }
+    default:
+      throw Error("Must dispatch a known action.")
+  }
+}
+
+function Select({ children, id, onSelect }) {
+  const inputRef = useRef()
+  const listRef = useRef()
+  const [state, dispatch] = useReducer(selectReducer, initialState)
+  const context = {
+    inputRef,
+    listRef,
+    state,
+    dispatch,
+    onSelect,
+    id
+  }
+  return <SelectContext.Provider value={context}>{children}</SelectContext.Provider>
+}
+
+const labelTransform = css`
+  font-size: 1.334rem;
+  transform: translate3d(0, -1rem, 0);
 `
 
-export default forwardRef(({ className, options = {}, ...props }, ref) => (
-  <StyledSelect className={className}>
-    <select {...props} ref={ref}>
-      {Object.keys(options).map((opt, idx) => (
-        <option key={idx} value={options[opt]}>
-          {opt}
-        </option>
-      ))}
-    </select>
-  </StyledSelect>
-))
+const iconTransform = css`
+  transform: rotate(180deg);
+`
+
+const inputTransform = css`
+  border-color: ${colors.blue_500};
+`
+
+const StyledSelectInput = styled.label`
+  position: relative;
+  display: block;
+  .select__input {
+    all: unset;
+    box-sizing: border-box;
+    padding: 3rem 2rem 1rem 2rem;
+    border: 2px solid ${colors.ui_500};
+    border-radius: 0.25rem;
+    width: 100%;
+    transition: 100ms;
+    ${({ hasValue, isOpen }) => (hasValue || isOpen) && inputTransform}
+  }
+  .select__value,
+  .select__label,
+  .select__icon {
+    position: absolute;
+  }
+  .select__label {
+    top: 2rem;
+    left: 2rem;
+    transition: 100ms;
+    color: ${colors.ui_700};
+    ${({ hasValue, isOpen }) => (hasValue || isOpen) && labelTransform}
+  }
+  .select__icon {
+    right: 2rem;
+    top: calc(2rem);
+    transition: 100ms;
+    ${({ isOpen }) => isOpen && iconTransform}
+  }
+  .select__value {
+    top: 3rem;
+    left: 2.25rem;
+  }
+`
+
+function Input(
+  { className, onFocus = noop, onChange = noop, label, search = true, ...props },
+  ref
+) {
+  const {
+    state: { inputValue, selectValue, isOpen },
+    inputRef,
+    dispatch
+  } = useContext(SelectContext)
+  function handleFocus() {
+    dispatch({ type: types.OPEN_LIST })
+  }
+  function handleChange({ target }) {
+    if (search) dispatch({ type: types.UPDATE_INPUT, value: target.value })
+  }
+  useImperativeHandle(ref, () => ({ ...inputRef }))
+  return (
+    <StyledSelectInput
+      {...props}
+      ref={inputRef}
+      isOpen={isOpen}
+      hasValue={inputValue.length || selectValue.length}
+      searchable
+    >
+      <input
+        ref={ref}
+        className="select__input"
+        value={inputValue}
+        onChange={wrapEvent(handleChange, onChange)}
+        onFocus={wrapEvent(handleFocus, onFocus)}
+      />
+      <span className="select__label">{label}</span>
+      {selectValue && <span className="select__value">{selectValue}</span>}
+      <ChevronDown className={`select__icon ${isOpen && "icon--is-open"}`} />
+    </StyledSelectInput>
+  )
+}
+
+const StyledList = styled(Card)`
+  display: block;
+  padding: 0;
+  margin-bottom: 2rem;
+  background: ${colors.ui_100};
+  border: 1px solid ${colors.ui_500};
+  border-radius: 0.25rem;
+  list-style: none;
+  max-height: calc(100vh - 10rem);
+  overflow-y: auto;
+`
+
+function List({ children, ...props }, ref) {
+  const {
+    state: { isOpen, width },
+    dispatch,
+    listRef,
+    inputRef,
+    id
+  } = useContext(SelectContext)
+  const inputBounds = useWindowResize(inputRef)
+  function position(popoverRect, targetRect) {
+    if (!popoverRect || !targetRect) return {}
+    return {
+      top: `${targetRect.top + targetRect.height + window.pageYOffset + 12}px`,
+      left: `${targetRect.left + window.pageXOffset}px`
+    }
+  }
+  function handleBlur({ target }) {
+    if (!isOpen) return null
+    const listEl = listRef.current
+    const targetEl = inputRef.current
+    if (!listEl?.contains(target) && !targetEl?.contains(target)) {
+      dispatch({ type: types.CLOSE_LIST })
+    }
+  }
+  useImperativeHandle(ref, () => ({ ...listRef }))
+  useEffect(() => {
+    if (isOpen) {
+      const { height } = listRef.current.getBoundingClientRect()
+      // Note, scrollBy behavior needs to be smooth to prevent the list appearing in the wrong spot.
+      // This is not supported by IE or Edge, so they're just going to have to scroll themselves.
+      window.scrollBy({
+        top: height,
+        behavior: "smooth"
+      })
+      document.addEventListener("click", handleBlur)
+    }
+    return () => document.removeEventListener("click", handleBlur)
+  }, [isOpen, handleBlur])
+  useEffect(() => {
+    if (isOpen) dispatch({ type: types.UPDATE_WIDTH, width: inputBounds.width })
+  }, [inputBounds, isOpen])
+  return isOpen ? (
+    <Popover getPosition={position} id={id} targetRef={inputRef}>
+      <StyledList {...props} as="ul" ref={listRef} style={{ width }}>
+        {children}
+      </StyledList>
+    </Popover>
+  ) : null
+}
+
+const StyledItem = styled.li`
+  padding: 2rem;
+  cursor: pointer;
+  &:hover {
+    background: ${colors.ui_300};
+  }
+  &.selected {
+    background: ${colors.blue_100};
+  }
+  &:not(:last-of-type) {
+    border-bottom: 1px solid ${colors.ui_500};
+  }
+`
+
+function Item(
+  { className, children, value = "", label = "", onClick = noop, ...props },
+  ref
+) {
+  const {
+    state: { currentValue, inputValue },
+    onSelect,
+    dispatch
+  } = useContext(SelectContext)
+  const [visibility, setVisibility] = useState(true)
+  function handleClick({ target }) {
+    dispatch({ type: types.SET_VALUE, value: target.dataset.value })
+    if (onSelect) onSelect(target.dataset.value)
+  }
+  const classes = currentValue === value ? `selected ${className}` : className
+  useEffect(() => {
+    function isFiltered() {
+      const matcher = new RegExp(inputValue, "i")
+      const search = label || value
+      if (!inputValue.length) return true
+      if (search.match(matcher)) return true
+      return false
+    }
+    setVisibility(isFiltered())
+  }, [inputValue])
+  return visibility ? (
+    <StyledItem
+      {...props}
+      ref={ref}
+      data-value={value}
+      onClick={wrapEvent(handleClick, onClick)}
+      className={classes}
+    >
+      {children}
+    </StyledItem>
+  ) : null
+}
+
+const SelectInput = forwardRef(Input)
+const SelectList = forwardRef(List)
+const SelectItem = forwardRef(Item)
+
+export { Select as default, SelectInput, SelectList, SelectItem }

--- a/src/select/select.test.js
+++ b/src/select/select.test.js
@@ -1,0 +1,17 @@
+import React from "react"
+import { render } from "@testing-library/react"
+import Select, { SelectInput, SelectList, SelectItem } from "src/select"
+
+describe("<Select />", () => {
+  it("Should render without crashing", () => {
+    const { container } = render(
+      <Select id="select-id">
+        <SelectInput />
+        <SelectList>
+          <SelectItem>Hello Item</SelectItem>
+        </SelectList>
+      </Select>
+    )
+    expect(container).not.toBeNull()
+  })
+})

--- a/src/tooltip/doc.mdx
+++ b/src/tooltip/doc.mdx
@@ -18,8 +18,7 @@ import Button from "src/button"
 ## Installation
 
 ```
-import {
-  Tooltip,
+import Tooltip, {
   TooltipContent,
   TooltipTarget
 } from "@rent_avail/elements/tooltip"


### PR DESCRIPTION
### Version 1.6.0
Closes #51 

## New Components
### `Select`
The select component replaces the browser equivalent of the same name. It gives the user an easy way to select an option from a set list.

## Updated Components
### `Grid`
The grid now takes a `theme` prop instead of a bunch of overrides. This allows more customization and aligns with the `styled-components` theme API, providing extensibility at an app-wide level.
### `Checkbox`
The checkbox component was slimmed down to reduce overall DOM nodes. This allows a lighter-weight implementation.
### `Radio`
The radio component's internal input & label class names are update to align with BEM. `.radio__input`, `.radio__label`

## Other
### `noop`
A new (admittedly almost entirely internal) util for returning an no operation function as the default for function component props.
### `useWindowResize`
A new hook that grabs a DOM elements boundingClientRect whenever the window resizes.