### PR TITLE
Downgrade framer-motion to 2.4.3

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -33,7 +33,7 @@
     "@rent_avail/typography": "^0.1.7",
     "@rent_avail/utils": "^0.2.0",
     "clsx": "^1.1.1",
-    "framer-motion": "^2.6.0",
+    "framer-motion": "2.4.3",
     "next": "^9.5.2",
     "next-compose-plugins": "^2.2.0",
     "next-mdx-enhanced": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.6",
     "eslint-plugin-react-hooks": "^4.1.0",
-    "framer-motion": "^2.6.0",
+    "framer-motion": "2.4.3",
     "jest": "^26.4.2",
     "lerna": "^3.22.0",
     "microbundle": "^0.12.2",

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@rent_avail/base": "^0.4.0",
     "@rent_avail/utils": "^0.2.2",
-    "framer-motion": "^2.6.0",
+    "framer-motion": "2.4.3",
     "polished": "^3.5.1",
     "styled-system": "^5.1.5"
   }

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -34,7 +34,7 @@
     "@rent_avail/layout": "^0.3.2",
     "@rent_avail/typography": "^0.1.10",
     "@rent_avail/utils": "^0.2.2",
-    "framer-motion": "^2.6.0",
+    "framer-motion": "2.4.3",
     "polished": "^3.6.5",
     "react-feather": "^2.0.8",
     "styled-system": "^5.1.5"

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -33,7 +33,7 @@
     "@rent_avail/base": "^0.4.0",
     "@rent_avail/typography": "^0.1.10",
     "@rent_avail/utils": "^0.2.2",
-    "framer-motion": "^2.6.0",
+    "framer-motion": "2.4.3",
     "react-feather": "^2.0.4",
     "styled-system": "^5.1.5"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2592,6 +2592,22 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@popmotion/easing@^1.0.1", "@popmotion/easing@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@popmotion/easing/-/easing-1.0.2.tgz#17d925c45b4bf44189e5a38038d149df42d8c0b4"
+  integrity sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw==
+
+"@popmotion/popcorn@^0.4.2":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@popmotion/popcorn/-/popcorn-0.4.4.tgz#a5f906fccdff84526e3fcb892712d7d8a98d6adc"
+  integrity sha512-jYO/8319fKoNLMlY4ZJPiPu8Ea8occYwRZhxpaNn/kZsK4QG2E7XFlXZMJBsTWDw7I1i0uaqyC4zn1nwEezLzg==
+  dependencies:
+    "@popmotion/easing" "^1.0.1"
+    framesync "^4.0.1"
+    hey-listen "^1.0.8"
+    style-value-types "^3.1.7"
+    tslib "^1.10.0"
+
 "@reach/router@^1.3.3":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"
@@ -8077,20 +8093,22 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-framer-motion@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-2.6.0.tgz#0434bb1f4f15d06c0a61872649b47712957d1efb"
-  integrity sha512-burXD+3V+bE0PsIopS7+EKiqtBv0bxCi0mK/y1mXCMlN8LqHnaiNFbgaVGPEYb8gcPtSeHW9Cu/8yb8kNxukiQ==
+framer-motion@2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-2.4.3.tgz#94bec070eb236e1b416a87dc3914cdea3f662bb3"
+  integrity sha512-bYuV5bJ0iViVD5kilMhMB01CoYct1JCiHFLjB9tXxkzGdrxO8A0GSPhYx/e56CsPwgqxYYU9RHvJEa/5gqXrbw==
   dependencies:
+    "@popmotion/easing" "^1.0.2"
+    "@popmotion/popcorn" "^0.4.2"
     framesync "^4.0.4"
     hey-listen "^1.0.8"
-    popmotion "9.0.0-rc.7"
+    popmotion "9.0.0-beta-8"
     style-value-types "^3.1.9"
     tslib "^1.10.0"
   optionalDependencies:
     "@emotion/is-prop-valid" "^0.8.2"
 
-framesync@^4.0.4:
+framesync@^4.0.1, framesync@^4.0.4:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/framesync/-/framesync-4.1.0.tgz#69a8db3ca432dc70d6a76ba882684a1497ef068a"
   integrity sha512-MmgZ4wCoeVxNbx2xp5hN/zPDCbLSKiDt4BbbslK7j/pM2lg5S0vhTNv1v8BCVb99JPIo6hXBFdwzU7Q4qcAaoQ==
@@ -12427,14 +12445,16 @@ polished@^3.4.4, polished@^3.5.1, polished@^3.6.4, polished@^3.6.5:
   dependencies:
     "@babel/runtime" "^7.9.2"
 
-popmotion@9.0.0-rc.7:
-  version "9.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.0.0-rc.7.tgz#b9f8ceddc322bc7489dd443355889d46be0ce211"
-  integrity sha512-sjPhOJtrQAQsSKsn5KKi0Q1E2pjnLozZ08m0zWX1OqPX3ERPH0txG2zwwHMnDoAHGHAkVujlAdFZ4ERLbKGMDA==
+popmotion@9.0.0-beta-8:
+  version "9.0.0-beta-8"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.0.0-beta-8.tgz#f5a709f11737734e84f2a6b73f9bcf25ee30c388"
+  integrity sha512-6eQzqursPvnP7ePvdfPeY4wFHmS3OLzNP8rJRvmfFfEIfpFqrQgLsM50Gd9AOvGKJtYJOFknNG+dsnzCpgIdAA==
   dependencies:
+    "@popmotion/easing" "^1.0.1"
+    "@popmotion/popcorn" "^0.4.2"
     framesync "^4.0.4"
     hey-listen "^1.0.8"
-    style-value-types "^3.1.9"
+    style-value-types "^3.1.6"
     tslib "^1.10.0"
 
 popper.js@^1.14.4, popper.js@^1.14.7:
@@ -15138,7 +15158,7 @@ style-to-object@0.3.0, style-to-object@^0.3.0:
   dependencies:
     inline-style-parser "0.1.1"
 
-style-value-types@^3.1.9:
+style-value-types@^3.1.6, style-value-types@^3.1.7, style-value-types@^3.1.9:
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-3.1.9.tgz#faf7da660d3f284ed695cff61ea197d85b9122cc"
   integrity sha512-050uqgB7WdvtgacoQKm+4EgKzJExVq0sieKBQQtJiU3Muh6MYcCp4T3M8+dfl6VOF2LR0NNwXBP1QYEed8DfIw==


### PR DESCRIPTION
Issue described in #110 is caused by the bug in `framer-motion` dependencies and is also described here - framer/motion#741. The issue occurs from versions `2.5.0` up to the latest atm `2.6.8`.

Proposal is to downgrade to the latest version w/o this bug (`2.4.3`) for the time being, rather that to try to implement workarounds.

Closes #110 