### PR TITLE
Fix Dialog scrolling behavior

### DIFF
--- a/packages/autocomplete/CHANGELOG.md
+++ b/packages/autocomplete/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.1](https://github.com/rentalutions/elements/compare/@rent_avail/autocomplete@0.2.0...@rent_avail/autocomplete@0.2.1) (2020-10-06)
+
+
+### Bug Fixes
+
+* **autocomplete:** remove defaultValue from input ([187fee3](https://github.com/rentalutions/elements/commit/187fee36dc7ffe2f61f63da5aef46def7cd191fd))
+* **autocomplete:** revisions from PR review ([f678a56](https://github.com/rentalutions/elements/commit/f678a561fa0a0d8cfb0064964d35d4d96ce64a8f))
+
+
+
+
+
 # [0.2.0](https://github.com/rentalutions/elements/compare/@rent_avail/autocomplete@0.1.7...@rent_avail/autocomplete@0.2.0) (2020-09-29)
 
 

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/autocomplete",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Component and hooks for using Google Places autocomplete.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -30,11 +30,11 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.1",
-    "@rent_avail/input": "^0.2.0",
-    "@rent_avail/layout": "^0.3.3",
-    "@rent_avail/popover": "^0.1.12",
-    "@rent_avail/utils": "^0.2.3",
+    "@rent_avail/base": "^0.4.2",
+    "@rent_avail/input": "^0.2.1",
+    "@rent_avail/layout": "^0.3.4",
+    "@rent_avail/popover": "^0.1.13",
+    "@rent_avail/utils": "^0.2.4",
     "styled-system": "^5.1.5"
   }
 }

--- a/packages/avatar/CHANGELOG.md
+++ b/packages/avatar/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.6](https://github.com/rentalutions/elements/compare/@rent_avail/avatar@0.2.5...@rent_avail/avatar@0.2.6) (2020-10-06)
+
+**Note:** Version bump only for package @rent_avail/avatar
+
+
+
+
+
 ## [0.2.5](https://github.com/rentalutions/elements/compare/@rent_avail/avatar@0.2.4...@rent_avail/avatar@0.2.5) (2020-09-29)
 
 **Note:** Version bump only for package @rent_avail/avatar

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/avatar",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Base styling and theme for Avail Design.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,8 +28,8 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.1",
-    "@rent_avail/utils": "^0.2.3",
+    "@rent_avail/base": "^0.4.2",
+    "@rent_avail/utils": "^0.2.4",
     "styled-system": "^5.1.5"
   }
 }

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.2](https://github.com/rentalutions/elements/compare/@rent_avail/base@0.4.1...@rent_avail/base@0.4.2) (2020-10-06)
+
+**Note:** Version bump only for package @rent_avail/base
+
+
+
+
+
 ## [0.4.1](https://github.com/rentalutions/elements/compare/@rent_avail/base@0.4.0...@rent_avail/base@0.4.1) (2020-09-29)
 
 

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/base",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Base styling and theme for Avail Design.",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/packages/controls/CHANGELOG.md
+++ b/packages/controls/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.6](https://github.com/rentalutions/elements/compare/@rent_avail/controls@0.2.5...@rent_avail/controls@0.2.6) (2020-10-06)
+
+**Note:** Version bump only for package @rent_avail/controls
+
+
+
+
+
 ## [0.2.5](https://github.com/rentalutions/elements/compare/@rent_avail/controls@0.2.4...@rent_avail/controls@0.2.5) (2020-09-29)
 
 **Note:** Version bump only for package @rent_avail/controls

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/controls",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "User control components.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -30,8 +30,8 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.1",
-    "@rent_avail/utils": "^0.2.3",
+    "@rent_avail/base": "^0.4.2",
+    "@rent_avail/utils": "^0.2.4",
     "framer-motion": "2.4.3",
     "polished": "^3.5.1",
     "styled-system": "^5.1.5"

--- a/packages/dialog/CHANGELOG.md
+++ b/packages/dialog/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.15](https://github.com/rentalutions/elements/compare/@rent_avail/dialog@0.1.14...@rent_avail/dialog@0.1.15) (2020-10-06)
+
+
+### Bug Fixes
+
+* **dialog:** body scroll lock mechanism ([4825f9c](https://github.com/rentalutions/elements/commit/4825f9c03249b0986ca3c7d64ecda6253c6d8e46))
+
+
+
+
+
 ## [0.1.14](https://github.com/rentalutions/elements/compare/@rent_avail/dialog@0.1.13...@rent_avail/dialog@0.1.14) (2020-09-29)
 
 **Note:** Version bump only for package @rent_avail/dialog

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/dialog",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Dialog components.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -30,10 +30,10 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.1",
-    "@rent_avail/layout": "^0.3.3",
-    "@rent_avail/typography": "^0.1.11",
-    "@rent_avail/utils": "^0.2.3",
+    "@rent_avail/base": "^0.4.2",
+    "@rent_avail/layout": "^0.3.4",
+    "@rent_avail/typography": "^0.1.12",
+    "@rent_avail/utils": "^0.2.4",
     "framer-motion": "2.4.3",
     "polished": "^3.6.5",
     "react-feather": "^2.0.8",

--- a/packages/dialog/src/dialogContext.js
+++ b/packages/dialog/src/dialogContext.js
@@ -3,19 +3,21 @@ import React, {
   cloneElement,
   forwardRef,
   useContext,
-  useEffect,
   useMemo,
+  useLayoutEffect,
 } from "react"
 import { noop } from "@rent_avail/utils"
+import { useBodyScrollLock } from "@rent_avail/utils/src"
 
 export const DialogContext = createContext()
 
 export function Dialog({ open = false, toggle = noop, id, ...props }) {
   const context = useMemo(() => ({ open, toggle, id }), [open, toggle, id])
-  useEffect(() => {
-    if (open) document.body.style.overflow = "hidden"
-    else document.body.style.overflow = "initial"
-    return () => (document.body.style.overflow = "initial")
+  const [lockBodyScroll, unlockBodyScroll] = useBodyScrollLock()
+  useLayoutEffect(() => {
+    if (open) lockBodyScroll()
+    else unlockBodyScroll()
+    return () => unlockBodyScroll()
   }, [open])
   return <DialogContext.Provider {...props} value={context} />
 }

--- a/packages/feedback/CHANGELOG.md
+++ b/packages/feedback/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.8](https://github.com/rentalutions/elements/compare/@rent_avail/feedback@0.2.7...@rent_avail/feedback@0.2.8) (2020-10-06)
+
+**Note:** Version bump only for package @rent_avail/feedback
+
+
+
+
+
 ## [0.2.7](https://github.com/rentalutions/elements/compare/@rent_avail/feedback@0.2.6...@rent_avail/feedback@0.2.7) (2020-09-29)
 
 **Note:** Version bump only for package @rent_avail/feedback

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/feedback",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Feedback components.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -30,9 +30,9 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.1",
-    "@rent_avail/typography": "^0.1.11",
-    "@rent_avail/utils": "^0.2.3",
+    "@rent_avail/base": "^0.4.2",
+    "@rent_avail/typography": "^0.1.12",
+    "@rent_avail/utils": "^0.2.4",
     "framer-motion": "2.4.3",
     "react-feather": "^2.0.4",
     "styled-system": "^5.1.5"

--- a/packages/input/CHANGELOG.md
+++ b/packages/input/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.1](https://github.com/rentalutions/elements/compare/@rent_avail/input@0.2.0...@rent_avail/input@0.2.1) (2020-10-06)
+
+**Note:** Version bump only for package @rent_avail/input
+
+
+
+
+
 # [0.2.0](https://github.com/rentalutions/elements/compare/@rent_avail/input@0.1.10...@rent_avail/input@0.2.0) (2020-09-29)
 
 

--- a/packages/input/input.stories.js
+++ b/packages/input/input.stories.js
@@ -1,11 +1,19 @@
 import React, { useState } from "react"
-import { Container } from "@rent_avail/layout"
 import { Calendar } from "react-feather"
+import { Box, Container, Grid, Col } from "@rent_avail/layout"
+import { Button } from "@rent_avail/controls"
+import {
+  Dialog,
+  DialogHeader,
+  DialogTarget,
+  ConfirmationDialog,
+} from "@rent_avail/dialog"
+import { Select, SelectInput, SelectList, SelectItem } from "@rent_avail/select"
 import Input from "./src"
 
 export default { title: "Input" }
 
-export function InputUsage() {
+export function BasicUsage() {
   const [name, setName] = useState("")
   const [color, setColor] = useState("")
   return (
@@ -31,6 +39,96 @@ export function InputUsage() {
         mb="3rem"
         required
       />
+    </Container>
+  )
+}
+
+export function DialogUsage() {
+  const [open, setOpen] = useState(true)
+  const options = [
+    { label: "Alabama", value: "AL" },
+    { label: "Alaska", value: "AK" },
+    { label: "Arizona", value: "AZ" },
+    { label: "Arkansas", value: "AR" },
+    { label: "California", value: "CA" },
+    { label: "Colorado", value: "CO" },
+    { label: "Connecticut", value: "CT" },
+  ]
+  const { 1: setSelection } = useState("")
+  return (
+    <Container sx={{ mt: "4rem" }}>
+      <Dialog open={open} toggle={() => setOpen((state) => !state)}>
+        <DialogTarget>
+          <Button mb="4rem" onClick={() => setOpen(true)}>
+            Click Me
+          </Button>
+        </DialogTarget>
+        <ConfirmationDialog>
+          <DialogHeader title="Hello World" />
+          <Grid>
+            <Col as={Input} label="Full Name" />
+            <Col as={Input} label="Full Name" />
+            <Col as={Input} label="Full Name" />
+            <Col>
+              <Select id="select-id" onSelect={(value) => setSelection(value)}>
+                <SelectInput label="Choose a state" />
+                <SelectList>
+                  {options.map(({ label, value }) => (
+                    <SelectItem key={value} value={value} label={label}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectList>
+              </Select>
+            </Col>
+            <Col as={Input} label="Full Name" />
+            <Col as={Input} label="Full Name" />
+          </Grid>
+        </ConfirmationDialog>
+      </Dialog>
+      <Grid>
+        <Col as="p">
+          Lorem ipsum dolor sit amet consectetur, adipisicing elit. Veniam atque
+          saepe impedit, quia recusandae eaque dignissimos nam cumque debitis ex
+          reiciendis! Voluptatum architecto reiciendis ipsa ducimus sequi
+          consequuntur ipsum sint!
+        </Col>
+        <Col as="p">
+          Lorem ipsum, dolor sit amet consectetur adipisicing elit. Commodi
+          perferendis fuga officia quaerat, ullam possimus, accusantium tempore
+          dolorem sunt a impedit odio sed rem placeat, assumenda deleniti
+          beatae! Inventore, blanditiis?
+        </Col>
+        <Col as="p">
+          Lorem ipsum dolor sit amet consectetur, adipisicing elit. Natus vero
+          ut unde similique mollitia dolore quisquam veniam aliquam illo
+          cupiditate. Perspiciatis modi nam iste recusandae labore aut. Optio,
+          dolorum ex!
+        </Col>
+        <Col as="p">
+          Lorem ipsum dolor sit, amet consectetur adipisicing elit. Magni ab
+          molestias nemo dolore quibusdam libero porro architecto, similique
+          consequuntur, vitae officia, dignissimos sit ratione unde delectus ut
+          rem vero ipsam.
+        </Col>
+        <Col as="p">
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Minus nam
+          blanditiis ad perferendis adipisci corporis rerum consequuntur qui
+          sit! Modi facere reprehenderit recusandae facilis culpa cupiditate
+          velit nihil qui dignissimos!
+        </Col>
+        <Col as="p">
+          Lorem ipsum dolor sit, amet consectetur adipisicing elit. Quia laborum
+          necessitatibus illo fugit iste provident, architecto ex sunt earum eum
+          ut pariatur consequatur quos, ratione rem, amet omnis non aliquam?
+        </Col>
+        <Col>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit. Similique
+          iusto dicta alias dolor enim animi laboriosam illum inventore,
+          eligendi numquam, asperiores voluptatibus quos magnam ut sed ratione,
+          blanditiis laborum pariatur?
+        </Col>
+      </Grid>
     </Container>
   )
 }

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/input",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Input components",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,8 +28,8 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.1",
-    "@rent_avail/utils": "^0.2.3",
+    "@rent_avail/base": "^0.4.2",
+    "@rent_avail/utils": "^0.2.4",
     "@styled-system/props": "^5.1.5",
     "clsx": "^1.1.0",
     "react-feather": "^2.0.4",

--- a/packages/layout/CHANGELOG.md
+++ b/packages/layout/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.4](https://github.com/rentalutions/elements/compare/@rent_avail/layout@0.3.3...@rent_avail/layout@0.3.4) (2020-10-06)
+
+**Note:** Version bump only for package @rent_avail/layout
+
+
+
+
+
 ## [0.3.3](https://github.com/rentalutions/elements/compare/@rent_avail/layout@0.3.2...@rent_avail/layout@0.3.3) (2020-09-29)
 
 **Note:** Version bump only for package @rent_avail/layout

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/layout",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Layout components.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,8 +28,8 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.1",
-    "@rent_avail/utils": "^0.2.3",
+    "@rent_avail/base": "^0.4.2",
+    "@rent_avail/utils": "^0.2.4",
     "styled-system": "^5.1.5"
   }
 }

--- a/packages/menu/CHANGELOG.md
+++ b/packages/menu/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.14](https://github.com/rentalutions/elements/compare/@rent_avail/menu@0.1.13...@rent_avail/menu@0.1.14) (2020-10-06)
+
+**Note:** Version bump only for package @rent_avail/menu
+
+
+
+
+
 ## [0.1.13](https://github.com/rentalutions/elements/compare/@rent_avail/menu@0.1.12...@rent_avail/menu@0.1.13) (2020-09-29)
 
 **Note:** Version bump only for package @rent_avail/menu

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/menu",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Menu component.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,10 +28,10 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.1",
-    "@rent_avail/layout": "^0.3.3",
-    "@rent_avail/popover": "^0.1.12",
-    "@rent_avail/utils": "^0.2.3",
+    "@rent_avail/base": "^0.4.2",
+    "@rent_avail/layout": "^0.3.4",
+    "@rent_avail/popover": "^0.1.13",
+    "@rent_avail/utils": "^0.2.4",
     "styled-system": "^5.1.5"
   }
 }

--- a/packages/popover/CHANGELOG.md
+++ b/packages/popover/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.13](https://github.com/rentalutions/elements/compare/@rent_avail/popover@0.1.12...@rent_avail/popover@0.1.13) (2020-10-06)
+
+**Note:** Version bump only for package @rent_avail/popover
+
+
+
+
+
 ## [0.1.12](https://github.com/rentalutions/elements/compare/@rent_avail/popover@0.1.11...@rent_avail/popover@0.1.12) (2020-09-29)
 
 **Note:** Version bump only for package @rent_avail/popover

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/popover",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Popover component.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,7 +28,7 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.1",
-    "@rent_avail/utils": "^0.2.3"
+    "@rent_avail/base": "^0.4.2",
+    "@rent_avail/utils": "^0.2.4"
   }
 }

--- a/packages/progress/CHANGELOG.md
+++ b/packages/progress/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.12](https://github.com/rentalutions/elements/compare/@rent_avail/progress@0.1.11...@rent_avail/progress@0.1.12) (2020-10-06)
+
+**Note:** Version bump only for package @rent_avail/progress
+
+
+
+
+
 ## [0.1.11](https://github.com/rentalutions/elements/compare/@rent_avail/progress@0.1.10...@rent_avail/progress@0.1.11) (2020-09-29)
 
 **Note:** Version bump only for package @rent_avail/progress

--- a/packages/progress/package.json
+++ b/packages/progress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/progress",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Progress components.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,7 +28,7 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.1",
-    "@rent_avail/utils": "^0.2.3"
+    "@rent_avail/base": "^0.4.2",
+    "@rent_avail/utils": "^0.2.4"
   }
 }

--- a/packages/select/CHANGELOG.md
+++ b/packages/select/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.15](https://github.com/rentalutions/elements/compare/@rent_avail/select@0.1.14...@rent_avail/select@0.1.15) (2020-10-06)
+
+**Note:** Version bump only for package @rent_avail/select
+
+
+
+
+
 ## [0.1.14](https://github.com/rentalutions/elements/compare/@rent_avail/select@0.1.13...@rent_avail/select@0.1.14) (2020-09-29)
 
 **Note:** Version bump only for package @rent_avail/select

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/select",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Select input component.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,10 +28,10 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.1",
-    "@rent_avail/layout": "^0.3.3",
-    "@rent_avail/popover": "^0.1.12",
-    "@rent_avail/utils": "^0.2.3",
+    "@rent_avail/base": "^0.4.2",
+    "@rent_avail/layout": "^0.3.4",
+    "@rent_avail/popover": "^0.1.13",
+    "@rent_avail/utils": "^0.2.4",
     "clsx": "^1.1.0",
     "react-feather": "^2.0.4",
     "styled-system": "^5.1.5"

--- a/packages/select/select.stories.js
+++ b/packages/select/select.stories.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react"
+import React, { useState, useRef, Fragment } from "react"
 import { Heading } from "@rent_avail/typography"
 import { Container } from "@rent_avail/layout"
 import {
@@ -25,7 +25,7 @@ function SelectExample() {
   ]
   const [state, setState] = useState("")
   return (
-    <>
+    <Fragment>
       <Heading mb="2rem">{state || "Select a value"}</Heading>
       <Select id="select-id" onSelect={(value) => setState(value)}>
         <SelectInput label="Choose a state" />
@@ -37,7 +37,7 @@ function SelectExample() {
           ))}
         </SelectList>
       </Select>
-    </>
+    </Fragment>
   )
 }
 

--- a/packages/select/src/index.js
+++ b/packages/select/src/index.js
@@ -264,20 +264,23 @@ function List({ children, style, ...props }, ref) {
   }
   useImperativeHandle(ref, () => ({ ...listRef }))
   useEffect(() => {
+    let canceled = false
+    function scrollWindow(top, fromBottom) {
+      if (!canceled) window.scrollBy(0, Math.max(top - fromBottom + 120, 0))
+    }
     if (isOpen) {
       const { current: input } = inputRef
       const { current: list } = listRef
-      const { top, width } = input.getBoundingClientRect()
+      const { top } = input.getBoundingClientRect()
       const { height } = list.getBoundingClientRect()
       const fromBottom = window.innerHeight - height
-      setTimeout(
-        () => window.scrollBy(0, Math.max(top - fromBottom + 120, 0)),
-        20
-      )
+      setTimeout(() => scrollWindow(top, fromBottom), 20)
       document.addEventListener("click", handleBlur)
-      setListWidth(width)
     }
-    return () => document.removeEventListener("click", handleBlur)
+    return () => {
+      canceled = true
+      document.removeEventListener("click", handleBlur)
+    }
   }, [isOpen, handleBlur])
   return isOpen ? (
     <Popover
@@ -290,7 +293,7 @@ function List({ children, style, ...props }, ref) {
         {...props}
         as="ul"
         ref={listRef}
-        style={{ ...style, width: listWidth || "auto" }}
+        style={{ ...style, width: inputRef.current.offsetWidth || "auto" }}
       >
         {children}
       </StyledList>

--- a/packages/skeleton/CHANGELOG.md
+++ b/packages/skeleton/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.13](https://github.com/rentalutions/elements/compare/@rent_avail/skeleton@0.1.12...@rent_avail/skeleton@0.1.13) (2020-10-06)
+
+**Note:** Version bump only for package @rent_avail/skeleton
+
+
+
+
+
 ## [0.1.12](https://github.com/rentalutions/elements/compare/@rent_avail/skeleton@0.1.11...@rent_avail/skeleton@0.1.12) (2020-09-29)
 
 **Note:** Version bump only for package @rent_avail/skeleton

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/skeleton",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Skeleton component for Avail Design",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -29,9 +29,9 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.1",
-    "@rent_avail/layout": "^0.3.3",
-    "@rent_avail/utils": "^0.2.3",
+    "@rent_avail/base": "^0.4.2",
+    "@rent_avail/layout": "^0.3.4",
+    "@rent_avail/utils": "^0.2.4",
     "clsx": "^1.1.0",
     "styled-system": "^5.1.5"
   }

--- a/packages/tag/CHANGELOG.md
+++ b/packages/tag/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.12](https://github.com/rentalutions/elements/compare/@rent_avail/tag@0.1.11...@rent_avail/tag@0.1.12) (2020-10-06)
+
+**Note:** Version bump only for package @rent_avail/tag
+
+
+
+
+
 ## [0.1.11](https://github.com/rentalutions/elements/compare/@rent_avail/tag@0.1.10...@rent_avail/tag@0.1.11) (2020-09-29)
 
 **Note:** Version bump only for package @rent_avail/tag

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/tag",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Chip component.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,8 +28,8 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.1",
-    "@rent_avail/utils": "^0.2.3",
+    "@rent_avail/base": "^0.4.2",
+    "@rent_avail/utils": "^0.2.4",
     "styled-system": "^5.1.5"
   }
 }

--- a/packages/tooltip/CHANGELOG.md
+++ b/packages/tooltip/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.13](https://github.com/rentalutions/elements/compare/@rent_avail/tooltip@0.1.12...@rent_avail/tooltip@0.1.13) (2020-10-06)
+
+**Note:** Version bump only for package @rent_avail/tooltip
+
+
+
+
+
 ## [0.1.12](https://github.com/rentalutions/elements/compare/@rent_avail/tooltip@0.1.11...@rent_avail/tooltip@0.1.12) (2020-09-29)
 
 **Note:** Version bump only for package @rent_avail/tooltip

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/tooltip",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Tooltip component.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,9 +28,9 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.1",
-    "@rent_avail/popover": "^0.1.12",
-    "@rent_avail/utils": "^0.2.3",
+    "@rent_avail/base": "^0.4.2",
+    "@rent_avail/popover": "^0.1.13",
+    "@rent_avail/utils": "^0.2.4",
     "styled-system": "^5.1.5"
   }
 }

--- a/packages/typography/CHANGELOG.md
+++ b/packages/typography/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.12](https://github.com/rentalutions/elements/compare/@rent_avail/typography@0.1.11...@rent_avail/typography@0.1.12) (2020-10-06)
+
+**Note:** Version bump only for package @rent_avail/typography
+
+
+
+
+
 ## [0.1.11](https://github.com/rentalutions/elements/compare/@rent_avail/typography@0.1.10...@rent_avail/typography@0.1.11) (2020-09-29)
 
 **Note:** Version bump only for package @rent_avail/typography

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/typography",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Type components.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,8 +28,8 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.1",
-    "@rent_avail/utils": "^0.2.3",
+    "@rent_avail/base": "^0.4.2",
+    "@rent_avail/utils": "^0.2.4",
     "styled-system": "^5.1.5"
   }
 }

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.4](https://github.com/rentalutions/elements/compare/@rent_avail/utils@0.2.3...@rent_avail/utils@0.2.4) (2020-10-06)
+
+
+### Bug Fixes
+
+* **dialog:** body scroll lock mechanism ([4825f9c](https://github.com/rentalutions/elements/commit/4825f9c03249b0986ca3c7d64ecda6253c6d8e46))
+
+
+
+
+
 ## [0.2.3](https://github.com/rentalutions/elements/compare/@rent_avail/utils@0.2.2...@rent_avail/utils@0.2.3) (2020-09-29)
 
 **Note:** Version bump only for package @rent_avail/utils

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/utils",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Utility functions.",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -255,6 +255,45 @@ export function useDates(startDate = new Date()) {
   }
 }
 
+export function useBodyScrollLock() {
+  const scrollLocked = useRef(false)
+  const originalScrollTop = useRef(0)
+  const originalStyles = useRef("")
+
+  const lock = () => {
+    if (scrollLocked.current) return
+    const scrollBarAdjustment =
+      window.innerWidth -
+      (document.scrollingElement || document.documentElement).clientWidth +
+      (parseInt(
+        window
+          .getComputedStyle(document.body)
+          .getPropertyValue("padding-right"),
+        10
+      ) || 0)
+    originalScrollTop.current = window.scrollY
+    originalStyles.current = document.body.style.cssText
+    document.body.style.cssText = `
+      ${originalStyles.current}
+      position: fixed;
+      width: 100%;
+      height: 100%;
+      top: -${originalScrollTop.current}px;
+      padding-right: ${scrollBarAdjustment}px;
+    `
+    scrollLocked.current = true
+  }
+
+  const unlock = () => {
+    if (!scrollLocked.current) return
+    document.body.style.cssText = originalStyles.current
+    if (originalScrollTop.current) window.scrollTo(0, originalScrollTop.current)
+    scrollLocked.current = false
+  }
+
+  return [lock, unlock]
+}
+
 export function throttle(fn, ms) {
   let timeout
   function exec() {


### PR DESCRIPTION
Changes the `dialog` scroll locking mechanism on `body` from `overflow: hidden` to using `position: fixed`, adds `useBodyScrollLock` hook to `utils`. 

This fixes the issue with Dialog scrolling unexpectedly on `input` focus in Chrome Mobile and should also enable `body` scroll lock in iOS Safari, since apparently `overflow: hidden` trick does not do that (can't confirm, [source](https://css-tricks.com/prevent-page-scrolling-when-a-modal-is-open/))

closes #117 

edit: [changes without the lerna stuff](https://github.com/rentalutions/elements/pull/118/files/4825f9c03249b0986ca3c7d64ecda6253c6d8e46)