### PR TITLE
Fix dialog bad import

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@
     "consistent-return": [0],
     "import/no-unresolved": "off",
     "import/no-extraneous-dependencies": "off",
+    "import/no-internal-modules": [2],
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/jsx-curly-brace-presence": [1, "ignore"],
     "react/prop-types": [1, { "skipUndeclared": true }],

--- a/packages/autocomplete/CHANGELOG.md
+++ b/packages/autocomplete/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.2](https://github.com/rentalutions/elements/compare/@rent_avail/autocomplete@0.2.1...@rent_avail/autocomplete@0.2.2) (2020-10-07)
+
+**Note:** Version bump only for package @rent_avail/autocomplete
+
+
+
+
+
 ## [0.2.1](https://github.com/rentalutions/elements/compare/@rent_avail/autocomplete@0.2.0...@rent_avail/autocomplete@0.2.1) (2020-10-06)
 
 

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/autocomplete",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Component and hooks for using Google Places autocomplete.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -30,11 +30,11 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.2",
-    "@rent_avail/input": "^0.2.1",
-    "@rent_avail/layout": "^0.3.4",
-    "@rent_avail/popover": "^0.1.13",
-    "@rent_avail/utils": "^0.2.4",
+    "@rent_avail/base": "^0.4.3",
+    "@rent_avail/input": "^0.2.2",
+    "@rent_avail/layout": "^0.3.5",
+    "@rent_avail/popover": "^0.1.14",
+    "@rent_avail/utils": "^0.2.5",
     "styled-system": "^5.1.5"
   }
 }

--- a/packages/avatar/CHANGELOG.md
+++ b/packages/avatar/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.7](https://github.com/rentalutions/elements/compare/@rent_avail/avatar@0.2.6...@rent_avail/avatar@0.2.7) (2020-10-07)
+
+**Note:** Version bump only for package @rent_avail/avatar
+
+
+
+
+
 ## [0.2.6](https://github.com/rentalutions/elements/compare/@rent_avail/avatar@0.2.5...@rent_avail/avatar@0.2.6) (2020-10-06)
 
 **Note:** Version bump only for package @rent_avail/avatar

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/avatar",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Base styling and theme for Avail Design.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,8 +28,8 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.2",
-    "@rent_avail/utils": "^0.2.4",
+    "@rent_avail/base": "^0.4.3",
+    "@rent_avail/utils": "^0.2.5",
     "styled-system": "^5.1.5"
   }
 }

--- a/packages/base/CHANGELOG.md
+++ b/packages/base/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.3](https://github.com/rentalutions/elements/compare/@rent_avail/base@0.4.2...@rent_avail/base@0.4.3) (2020-10-07)
+
+**Note:** Version bump only for package @rent_avail/base
+
+
+
+
+
 ## [0.4.2](https://github.com/rentalutions/elements/compare/@rent_avail/base@0.4.1...@rent_avail/base@0.4.2) (2020-10-06)
 
 **Note:** Version bump only for package @rent_avail/base

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/base",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Base styling and theme for Avail Design.",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/packages/controls/CHANGELOG.md
+++ b/packages/controls/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.7](https://github.com/rentalutions/elements/compare/@rent_avail/controls@0.2.6...@rent_avail/controls@0.2.7) (2020-10-07)
+
+**Note:** Version bump only for package @rent_avail/controls
+
+
+
+
+
 ## [0.2.6](https://github.com/rentalutions/elements/compare/@rent_avail/controls@0.2.5...@rent_avail/controls@0.2.6) (2020-10-06)
 
 **Note:** Version bump only for package @rent_avail/controls

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/controls",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "User control components.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -30,8 +30,8 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.2",
-    "@rent_avail/utils": "^0.2.4",
+    "@rent_avail/base": "^0.4.3",
+    "@rent_avail/utils": "^0.2.5",
     "framer-motion": "2.4.3",
     "polished": "^3.5.1",
     "styled-system": "^5.1.5"

--- a/packages/dialog/CHANGELOG.md
+++ b/packages/dialog/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.16](https://github.com/rentalutions/elements/compare/@rent_avail/dialog@0.1.15...@rent_avail/dialog@0.1.16) (2020-10-07)
+
+
+### Bug Fixes
+
+* **dialog:** bad import of useBodyScrollLock ([160e3c8](https://github.com/rentalutions/elements/commit/160e3c8dfe251894e5283a41c9e4ff2498c07f2b))
+
+
+
+
+
 ## [0.1.15](https://github.com/rentalutions/elements/compare/@rent_avail/dialog@0.1.14...@rent_avail/dialog@0.1.15) (2020-10-06)
 
 

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/dialog",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Dialog components.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -30,10 +30,10 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.2",
-    "@rent_avail/layout": "^0.3.4",
-    "@rent_avail/typography": "^0.1.12",
-    "@rent_avail/utils": "^0.2.4",
+    "@rent_avail/base": "^0.4.3",
+    "@rent_avail/layout": "^0.3.5",
+    "@rent_avail/typography": "^0.1.13",
+    "@rent_avail/utils": "^0.2.5",
     "framer-motion": "2.4.3",
     "polished": "^3.6.5",
     "react-feather": "^2.0.8",

--- a/packages/dialog/src/dialogContext.js
+++ b/packages/dialog/src/dialogContext.js
@@ -6,8 +6,7 @@ import React, {
   useMemo,
   useLayoutEffect,
 } from "react"
-import { noop } from "@rent_avail/utils"
-import { useBodyScrollLock } from "@rent_avail/utils/src"
+import { noop, useBodyScrollLock } from "@rent_avail/utils"
 
 export const DialogContext = createContext()
 

--- a/packages/feedback/CHANGELOG.md
+++ b/packages/feedback/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.9](https://github.com/rentalutions/elements/compare/@rent_avail/feedback@0.2.8...@rent_avail/feedback@0.2.9) (2020-10-07)
+
+**Note:** Version bump only for package @rent_avail/feedback
+
+
+
+
+
 ## [0.2.8](https://github.com/rentalutions/elements/compare/@rent_avail/feedback@0.2.7...@rent_avail/feedback@0.2.8) (2020-10-06)
 
 **Note:** Version bump only for package @rent_avail/feedback

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/feedback",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Feedback components.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -30,9 +30,9 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.2",
-    "@rent_avail/typography": "^0.1.12",
-    "@rent_avail/utils": "^0.2.4",
+    "@rent_avail/base": "^0.4.3",
+    "@rent_avail/typography": "^0.1.13",
+    "@rent_avail/utils": "^0.2.5",
     "framer-motion": "2.4.3",
     "react-feather": "^2.0.4",
     "styled-system": "^5.1.5"

--- a/packages/input/CHANGELOG.md
+++ b/packages/input/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.2](https://github.com/rentalutions/elements/compare/@rent_avail/input@0.2.1...@rent_avail/input@0.2.2) (2020-10-07)
+
+**Note:** Version bump only for package @rent_avail/input
+
+
+
+
+
 ## [0.2.1](https://github.com/rentalutions/elements/compare/@rent_avail/input@0.2.0...@rent_avail/input@0.2.1) (2020-10-06)
 
 **Note:** Version bump only for package @rent_avail/input

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/input",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Input components",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,8 +28,8 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.2",
-    "@rent_avail/utils": "^0.2.4",
+    "@rent_avail/base": "^0.4.3",
+    "@rent_avail/utils": "^0.2.5",
     "@styled-system/props": "^5.1.5",
     "clsx": "^1.1.0",
     "react-feather": "^2.0.4",

--- a/packages/layout/CHANGELOG.md
+++ b/packages/layout/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.5](https://github.com/rentalutions/elements/compare/@rent_avail/layout@0.3.4...@rent_avail/layout@0.3.5) (2020-10-07)
+
+**Note:** Version bump only for package @rent_avail/layout
+
+
+
+
+
 ## [0.3.4](https://github.com/rentalutions/elements/compare/@rent_avail/layout@0.3.3...@rent_avail/layout@0.3.4) (2020-10-06)
 
 **Note:** Version bump only for package @rent_avail/layout

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/layout",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Layout components.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,8 +28,8 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.2",
-    "@rent_avail/utils": "^0.2.4",
+    "@rent_avail/base": "^0.4.3",
+    "@rent_avail/utils": "^0.2.5",
     "styled-system": "^5.1.5"
   }
 }

--- a/packages/menu/CHANGELOG.md
+++ b/packages/menu/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.15](https://github.com/rentalutions/elements/compare/@rent_avail/menu@0.1.14...@rent_avail/menu@0.1.15) (2020-10-07)
+
+**Note:** Version bump only for package @rent_avail/menu
+
+
+
+
+
 ## [0.1.14](https://github.com/rentalutions/elements/compare/@rent_avail/menu@0.1.13...@rent_avail/menu@0.1.14) (2020-10-06)
 
 **Note:** Version bump only for package @rent_avail/menu

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/menu",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Menu component.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,10 +28,10 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.2",
-    "@rent_avail/layout": "^0.3.4",
-    "@rent_avail/popover": "^0.1.13",
-    "@rent_avail/utils": "^0.2.4",
+    "@rent_avail/base": "^0.4.3",
+    "@rent_avail/layout": "^0.3.5",
+    "@rent_avail/popover": "^0.1.14",
+    "@rent_avail/utils": "^0.2.5",
     "styled-system": "^5.1.5"
   }
 }

--- a/packages/popover/CHANGELOG.md
+++ b/packages/popover/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.14](https://github.com/rentalutions/elements/compare/@rent_avail/popover@0.1.13...@rent_avail/popover@0.1.14) (2020-10-07)
+
+**Note:** Version bump only for package @rent_avail/popover
+
+
+
+
+
 ## [0.1.13](https://github.com/rentalutions/elements/compare/@rent_avail/popover@0.1.12...@rent_avail/popover@0.1.13) (2020-10-06)
 
 **Note:** Version bump only for package @rent_avail/popover

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/popover",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Popover component.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,7 +28,7 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.2",
-    "@rent_avail/utils": "^0.2.4"
+    "@rent_avail/base": "^0.4.3",
+    "@rent_avail/utils": "^0.2.5"
   }
 }

--- a/packages/progress/CHANGELOG.md
+++ b/packages/progress/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.13](https://github.com/rentalutions/elements/compare/@rent_avail/progress@0.1.12...@rent_avail/progress@0.1.13) (2020-10-07)
+
+**Note:** Version bump only for package @rent_avail/progress
+
+
+
+
+
 ## [0.1.12](https://github.com/rentalutions/elements/compare/@rent_avail/progress@0.1.11...@rent_avail/progress@0.1.12) (2020-10-06)
 
 **Note:** Version bump only for package @rent_avail/progress

--- a/packages/progress/package.json
+++ b/packages/progress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/progress",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Progress components.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,7 +28,7 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.2",
-    "@rent_avail/utils": "^0.2.4"
+    "@rent_avail/base": "^0.4.3",
+    "@rent_avail/utils": "^0.2.5"
   }
 }

--- a/packages/select/CHANGELOG.md
+++ b/packages/select/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.16](https://github.com/rentalutions/elements/compare/@rent_avail/select@0.1.15...@rent_avail/select@0.1.16) (2020-10-07)
+
+**Note:** Version bump only for package @rent_avail/select
+
+
+
+
+
 ## [0.1.15](https://github.com/rentalutions/elements/compare/@rent_avail/select@0.1.14...@rent_avail/select@0.1.15) (2020-10-06)
 
 **Note:** Version bump only for package @rent_avail/select

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/select",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Select input component.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,10 +28,10 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.2",
-    "@rent_avail/layout": "^0.3.4",
-    "@rent_avail/popover": "^0.1.13",
-    "@rent_avail/utils": "^0.2.4",
+    "@rent_avail/base": "^0.4.3",
+    "@rent_avail/layout": "^0.3.5",
+    "@rent_avail/popover": "^0.1.14",
+    "@rent_avail/utils": "^0.2.5",
     "clsx": "^1.1.0",
     "react-feather": "^2.0.4",
     "styled-system": "^5.1.5"

--- a/packages/skeleton/CHANGELOG.md
+++ b/packages/skeleton/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.14](https://github.com/rentalutions/elements/compare/@rent_avail/skeleton@0.1.13...@rent_avail/skeleton@0.1.14) (2020-10-07)
+
+**Note:** Version bump only for package @rent_avail/skeleton
+
+
+
+
+
 ## [0.1.13](https://github.com/rentalutions/elements/compare/@rent_avail/skeleton@0.1.12...@rent_avail/skeleton@0.1.13) (2020-10-06)
 
 **Note:** Version bump only for package @rent_avail/skeleton

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/skeleton",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Skeleton component for Avail Design",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -29,9 +29,9 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.2",
-    "@rent_avail/layout": "^0.3.4",
-    "@rent_avail/utils": "^0.2.4",
+    "@rent_avail/base": "^0.4.3",
+    "@rent_avail/layout": "^0.3.5",
+    "@rent_avail/utils": "^0.2.5",
     "clsx": "^1.1.0",
     "styled-system": "^5.1.5"
   }

--- a/packages/tag/CHANGELOG.md
+++ b/packages/tag/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.13](https://github.com/rentalutions/elements/compare/@rent_avail/tag@0.1.12...@rent_avail/tag@0.1.13) (2020-10-07)
+
+**Note:** Version bump only for package @rent_avail/tag
+
+
+
+
+
 ## [0.1.12](https://github.com/rentalutions/elements/compare/@rent_avail/tag@0.1.11...@rent_avail/tag@0.1.12) (2020-10-06)
 
 **Note:** Version bump only for package @rent_avail/tag

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/tag",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Chip component.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,8 +28,8 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.2",
-    "@rent_avail/utils": "^0.2.4",
+    "@rent_avail/base": "^0.4.3",
+    "@rent_avail/utils": "^0.2.5",
     "styled-system": "^5.1.5"
   }
 }

--- a/packages/tooltip/CHANGELOG.md
+++ b/packages/tooltip/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.14](https://github.com/rentalutions/elements/compare/@rent_avail/tooltip@0.1.13...@rent_avail/tooltip@0.1.14) (2020-10-07)
+
+**Note:** Version bump only for package @rent_avail/tooltip
+
+
+
+
+
 ## [0.1.13](https://github.com/rentalutions/elements/compare/@rent_avail/tooltip@0.1.12...@rent_avail/tooltip@0.1.13) (2020-10-06)
 
 **Note:** Version bump only for package @rent_avail/tooltip

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/tooltip",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Tooltip component.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,9 +28,9 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.2",
-    "@rent_avail/popover": "^0.1.13",
-    "@rent_avail/utils": "^0.2.4",
+    "@rent_avail/base": "^0.4.3",
+    "@rent_avail/popover": "^0.1.14",
+    "@rent_avail/utils": "^0.2.5",
     "styled-system": "^5.1.5"
   }
 }

--- a/packages/typography/CHANGELOG.md
+++ b/packages/typography/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.13](https://github.com/rentalutions/elements/compare/@rent_avail/typography@0.1.12...@rent_avail/typography@0.1.13) (2020-10-07)
+
+**Note:** Version bump only for package @rent_avail/typography
+
+
+
+
+
 ## [0.1.12](https://github.com/rentalutions/elements/compare/@rent_avail/typography@0.1.11...@rent_avail/typography@0.1.12) (2020-10-06)
 
 **Note:** Version bump only for package @rent_avail/typography

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/typography",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Type components.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -28,8 +28,8 @@
     "styled-components": "^5.1.1"
   },
   "dependencies": {
-    "@rent_avail/base": "^0.4.2",
-    "@rent_avail/utils": "^0.2.4",
+    "@rent_avail/base": "^0.4.3",
+    "@rent_avail/utils": "^0.2.5",
     "styled-system": "^5.1.5"
   }
 }

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.5](https://github.com/rentalutions/elements/compare/@rent_avail/utils@0.2.4...@rent_avail/utils@0.2.5) (2020-10-07)
+
+
+### Bug Fixes
+
+* **utils:** disables "smooth" scrolling in body scroll locking mechanism ([f951e0b](https://github.com/rentalutions/elements/commit/f951e0badbef3600141fb3c128e4e8c2c2ed84bc))
+
+
+
+
+
 ## [0.2.4](https://github.com/rentalutions/elements/compare/@rent_avail/utils@0.2.3...@rent_avail/utils@0.2.4) (2020-10-06)
 
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/utils",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Utility functions.",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -256,6 +256,7 @@ export function useDates(startDate = new Date()) {
 }
 
 export function useBodyScrollLock() {
+  const scrollElement = document.scrollingElement || document.documentElement
   const scrollLocked = useRef(false)
   const originalScrollTop = useRef(0)
   const originalStyles = useRef("")
@@ -264,7 +265,7 @@ export function useBodyScrollLock() {
     if (scrollLocked.current) return
     const scrollBarAdjustment =
       window.innerWidth -
-      (document.scrollingElement || document.documentElement).clientWidth +
+      scrollElement.clientWidth +
       (parseInt(
         window
           .getComputedStyle(document.body)
@@ -277,10 +278,10 @@ export function useBodyScrollLock() {
       ${originalStyles.current}
       position: fixed;
       width: 100%;
-      height: 100%;
       top: -${originalScrollTop.current}px;
       padding-right: ${scrollBarAdjustment}px;
     `
+    scrollElement.style.scrollBehavior = "auto"
     scrollLocked.current = true
   }
 
@@ -288,6 +289,7 @@ export function useBodyScrollLock() {
     if (!scrollLocked.current) return
     document.body.style.cssText = originalStyles.current
     if (originalScrollTop.current) window.scrollTo(0, originalScrollTop.current)
+    scrollElement.style.scrollBehavior = ""
     scrollLocked.current = false
   }
 


### PR DESCRIPTION
Fixes the bad internal import missed in previous PR. To prevent this from happening again a `import/no-internal-modules` rule was added to ESLint config.

Also adds disabling `scroll-behavior: smooth` to scroll locking mechanism to avoid weird page movement on re-enabling `body` scrolling