### PR TITLE
Update Fluid Progress Label

### DIFF
--- a/packages/progress/src/index.js
+++ b/packages/progress/src/index.js
@@ -62,7 +62,7 @@ export function FluidProgress({ label, current, total, ...props }) {
         />
         <p className="steps">{`${current} / ${total}`}</p>
       </div>
-      <p className="small label">{label}</p>
+      {label && <p className="small label">{label}</p>}
     </StyledFluid>
   )
 }


### PR DESCRIPTION
Change to the fluid progress component to avoid rendering an empty text node if no label is present.

fixes #41
