### PR TITLE
Replace useImperativeHandle with a utility function mergeRefs

### DIFF
--- a/packages/menu/src/index.js
+++ b/packages/menu/src/index.js
@@ -12,7 +12,7 @@ import React, {
 import styled from "styled-components"
 import Popover from "@rent_avail/popover"
 import { Card } from "@rent_avail/layout"
-import { wrapEvent } from "@rent_avail/utils"
+import { mergeRefs, wrapEvent } from "@rent_avail/utils"
 
 const MenuContext = createContext()
 
@@ -80,11 +80,10 @@ function Target({ children, ...rest }, ref) {
         return false
     }
   }
-  useImperativeHandle(ref, () => ({ ...targetRef }))
   const passedProps = {
     id,
     type: "button",
-    ref: targetRef,
+    ref: mergeRefs(ref, targetRef),
     onClick: wrapEvent(onClick, openMenu),
     onKeyDown: wrapEvent(onKeyDown, handleKeyDown),
     "aria-expanded": isOpen,

--- a/packages/popover/src/index.js
+++ b/packages/popover/src/index.js
@@ -1,15 +1,13 @@
 /* eslint-disable no-nested-ternary */
-import React, {
-  useRef,
-  forwardRef,
-  useImperativeHandle,
-  useState,
-  useEffect,
-  useMemo,
-} from "react"
+import React, { useRef, forwardRef, useState, useEffect, useMemo } from "react"
 import { createPortal } from "react-dom"
 import { Box } from "@rent_avail/layout"
-import { usePortal, closestScrollable, useResize } from "@rent_avail/utils"
+import {
+  usePortal,
+  closestScrollable,
+  useResize,
+  mergeRefs,
+} from "@rent_avail/utils"
 import { dequal } from "dequal"
 
 export function getPosition({ popover, target, parent, position: { x, y } }) {
@@ -82,7 +80,6 @@ const Popover = forwardRef(function Popover(
     left: 0,
     visibility: "hidden",
   })
-  useImperativeHandle(ref, () => ({ ...popoverRef }))
   useEffect(() => {
     const newPos = getPosition({
       popover: popoverBounds,
@@ -96,7 +93,7 @@ const Popover = forwardRef(function Popover(
     <Box
       {...rest}
       as="aside"
-      ref={popoverRef}
+      ref={mergeRefs(ref, popoverRef)}
       style={{ ...style, position: "absolute", ...currentPosition }}
     />,
     portalTarget

--- a/packages/select/src/SelectInput.js
+++ b/packages/select/src/SelectInput.js
@@ -1,7 +1,7 @@
 import React, { useContext, forwardRef, useImperativeHandle } from "react"
 import { Box } from "@rent_avail/layout"
 import Input from "@rent_avail/input"
-import { wrapEvent } from "@rent_avail/utils"
+import { wrapEvent, mergeRefs } from "@rent_avail/utils"
 import { ChevronDown } from "react-feather"
 import clsx from "clsx"
 import { SelectContext, types } from "./SelectProvider"
@@ -23,12 +23,11 @@ function SelectInput(
     if (key === "ArrowDown") listRef.current.firstChild.focus()
     if (key === "Tab") dispatch({ type: types.CLOSE_LIST })
   }
-  useImperativeHandle(ref, () => ({ ...inputRef?.current }))
   return (
     <Box as="section" sx={{ position: "relative", ...sx }}>
       <Input
         {...props}
-        ref={inputRef}
+        ref={mergeRefs(ref, inputRef)}
         value={state.typeAheadQuery}
         onFocus={wrapEvent(onFocus, handleFocus)}
         onChange={wrapEvent(onChange, handleChange)}

--- a/packages/select/src/SelectItem.js
+++ b/packages/select/src/SelectItem.js
@@ -7,7 +7,7 @@ import React, {
   useState,
 } from "react"
 import { Box } from "@rent_avail/layout"
-import { wrapEvent } from "@rent_avail/utils"
+import { wrapEvent, mergeRefs } from "@rent_avail/utils"
 import { SelectContext, types } from "./SelectProvider"
 
 function SelectItem(
@@ -37,7 +37,6 @@ function SelectItem(
     if (key === "Enter") handleSelect({ target })
     if (key === "Escape") dispatch({ type: types.CLOSE_LIST })
   }
-  useImperativeHandle(ref, () => ({ ...itemRef?.current }))
   useEffect(() => {
     function isFiltered() {
       const matcher = new RegExp(state.typeAheadQuery, "i")
@@ -51,7 +50,7 @@ function SelectItem(
   return visible ? (
     <Box
       {...props}
-      ref={itemRef}
+      ref={mergeRefs(ref, itemRef)}
       as={as}
       data-value={itemValue}
       tabIndex="0"

--- a/packages/select/src/SelectList.js
+++ b/packages/select/src/SelectList.js
@@ -6,14 +6,13 @@ import React, {
 } from "react"
 import Popover from "@rent_avail/popover"
 import { Box } from "@rent_avail/layout"
-import { useResize } from "@rent_avail/utils"
+import { useResize, mergeRefs } from "@rent_avail/utils"
 import { SelectContext, types } from "./SelectProvider"
 
 function SelectList({ as = "ul", sx = {}, style = {}, ...props }, ref) {
   const { state, dispatch, listRef, inputRef } = useContext(SelectContext)
   const inputBounds = useResize(inputRef)
   const listBounds = useResize(listRef)
-  useImperativeHandle(ref, () => ({ ...listRef?.current }))
   useEffect(() => {
     let cancelled = false
     function handleDocumentClick({ target }) {
@@ -46,7 +45,7 @@ function SelectList({ as = "ul", sx = {}, style = {}, ...props }, ref) {
     >
       <Box
         {...props}
-        ref={listRef}
+        ref={mergeRefs(ref, listRef)}
         as={as}
         sx={{
           display: "block",

--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -9,7 +9,7 @@ import React, {
   Children,
 } from "react"
 import styled from "styled-components"
-import { wrapEvent } from "@rent_avail/utils"
+import { mergeRefs, wrapEvent } from "@rent_avail/utils"
 import Popover from "@rent_avail/popover"
 
 const TooltipContext = createContext()
@@ -52,7 +52,6 @@ function Target({ children, ...props }, ref) {
     state: { isOpen },
     dispatch,
   } = useContext(TooltipContext)
-  useImperativeHandle(ref, () => ({ ...targetRef }))
   const child = Children.only(children)
   const { onBlur, onFocus, onMouseEnter, onMouseLeave, style } = child.props
   function handleOpen() {
@@ -63,7 +62,7 @@ function Target({ children, ...props }, ref) {
   }
   return cloneElement(child, {
     ...props,
-    ref: targetRef,
+    ref: mergeRefs(ref, targetRef),
     id,
     tabIndex: 0,
     type: "button",
@@ -96,7 +95,6 @@ function Content({ children, position, ...props }, ref) {
     popoverRef,
     targetRef,
   } = useContext(TooltipContext)
-  useImperativeHandle(ref, () => ({ ...tooltipRef }))
   return isOpen ? (
     <Popover
       style={{ zIndex: "9999" }}
@@ -106,7 +104,7 @@ function Content({ children, position, ...props }, ref) {
     >
       <StyledTooltip
         {...props}
-        ref={tooltipRef}
+        ref={mergeRefs(ref, tooltipRef)}
         role="tooltip"
         id={id}
         aria-hidden={!isOpen}

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -3,6 +3,23 @@ import ResizeObserver from "resize-observer-polyfill"
 import "intersection-observer"
 import CalendarDates from "calendar-dates"
 
+function assignRef(ref, value) {
+  if (ref === null) return
+  if (typeof ref === "function") {
+    ref(value)
+    return
+  }
+  try {
+    ref.current = value
+  } catch (error) {
+    throw new Error(`Cannot assign ${value} to ${ref}`)
+  }
+}
+
+export function mergeRefs(...refs) {
+  return (value) => refs.forEach((ref) => assignRef(ref, value))
+}
+
 export function useResize(target, parent) {
   const [bounds, setBounds] = useState({})
   const resize = useCallback(() => {


### PR DESCRIPTION
`useImperativeHandle` is buggy with multiple layers of passed refs. This means that sometimes the component should spread `innerRef.current` and other times just `innerRef`.

I've noticed in other libraries / across the web custom merge ref utility functions and it seems to fix any ref issues and force the component props to be deterministic.

## `mergeRef`

This function takes an unlimited number of refs as arguments and applies them on top of one another, returning a single ref object to the consumer.

This should update the following packages directly.

`@rent_avail/utils`, `@rent_avail/popover`, `@rent_avail/select`, `@rent_avail/menu`, `@rent_avail/tooltip`, & `@rent_avail/autocomplete`.

It should bump all packages though to keep utils current across them.