### PR TITLE
Removing popover from menu list and rendering it with absolute position

### DIFF
--- a/packages/menu/src/index.js
+++ b/packages/menu/src/index.js
@@ -103,7 +103,6 @@ const StyledList = styled(Card)`
 
 function List({ children, ...rest }, ref) {
   const { targetRef, menuRef, closeMenu, isOpen } = useContext(MenuContext)
-  useImperativeHandle(ref, () => ({ ...menuRef }))
   function handleBlur({ target }) {
     if (!isOpen) return null
     const menuEl = menuRef.current


### PR DESCRIPTION
I'm opening this as a draft while I'm not sure on the possible side effects of this change.

What do you feel about this change in a general way?

There is any reason for us to keep using the `Popover` approach?

Are we currently using the `position` prop anywhere, or can we fix it to `absolute`?
