### PR TITLE
bugfix/down-arrow-in-Select-does-not-open-list

### DIFF
--- a/packages/select/src/select-input.js
+++ b/packages/select/src/select-input.js
@@ -15,7 +15,7 @@ function useSelectInput({
   ...props
 }) {
   const { state, dispatch, listRef, inputRef } = useContext(SelectContext)
-  function handleFocus() {
+  function openList() {
     dispatch({ type: types.OPEN_LIST })
   }
   function handleChange({ target }) {
@@ -32,7 +32,7 @@ function useSelectInput({
     inputProps: {
       ...props,
       className: clsx(className, { filled: state.value.length }),
-      onFocus: wrapEvent(onFocus, handleFocus),
+      onFocus: wrapEvent(onFocus, openList),
       onChange: wrapEvent(onChange, handleChange),
       onKeyDown: wrapEvent(onKeyDown, handleKeyDown),
       ref: mergeRefs(ref, inputRef),
@@ -42,11 +42,12 @@ function useSelectInput({
       hidden: !state.value.length,
       children: state.defaultLabel.length ? state.defaultLabel : state.value,
     },
+    openList,
   }
 }
 
 function SelectInput({ sx, ...props }, ref) {
-  const { inputProps, valueBoxProps, state } = useSelectInput({ ...props, ref })
+  const { inputProps, valueBoxProps, state, openList } = useSelectInput({ ...props, ref })
   return (
     <Box as="section" sx={{ position: "relative", ...sx }}>
       <Input
@@ -64,6 +65,7 @@ function SelectInput({ sx, ...props }, ref) {
           transition: "200ms",
           transform: state.isOpen ? "rotate(180deg)" : "rotate(0)",
         }}
+        onClick={openList}
       />
       <Box
         {...valueBoxProps}


### PR DESCRIPTION
**Resolves**

- Category & Associated Rental Dropdown Arrows Not Responsive in I&E tracking QA feedback items line 1
https://airtable.com/apprCDn2OPfeVureu/tblDpQRFYw184QOL7/viwp95BaUAhHiTqaP?blocks=hide

**Why**

- `onFocus` is not triggered when the down arrow icon is clicked.

**Solution**

- pass openList (previously handleFocus) function to SelectInput, so clicking the icon can call the function

**Also Included**

N/A

**Screenshots**

![Screen Shot 2021-12-08 at 5 09 27 PM](https://user-images.githubusercontent.com/18016578/145305772-b378d81f-912a-465d-8aa7-77e1c80dd353.png)

