### PR TITLE
Fix Popover position when parent ref is provided

### DIFF
--- a/packages/autocomplete/CHANGELOG.md
+++ b/packages/autocomplete/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.17](https://github.com/rentalutions/elements/compare/@rent_avail/autocomplete@0.3.16...@rent_avail/autocomplete@0.3.17) (2022-08-31)
+
+**Note:** Version bump only for package @rent_avail/autocomplete
+
+
+
+
+
 ## [0.3.16](https://github.com/rentalutions/elements/compare/@rent_avail/autocomplete@0.3.15...@rent_avail/autocomplete@0.3.16) (2022-04-18)
 
 **Note:** Version bump only for package @rent_avail/autocomplete

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/autocomplete",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Component and hooks for using Google Places autocomplete.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -32,7 +32,7 @@
     "@rent_avail/base": "^0.5.0",
     "@rent_avail/input": "^0.4.6",
     "@rent_avail/layout": "^0.3.13",
-    "@rent_avail/popover": "^0.3.10",
+    "@rent_avail/popover": "^0.3.11",
     "@rent_avail/utils": "^0.5.1",
     "styled-system": "^5.1.5"
   }

--- a/packages/avatar/CHANGELOG.md
+++ b/packages/avatar/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.12](https://github.com/rentalutions/elements/compare/@rent_avail/avatar@0.3.10...@rent_avail/avatar@0.3.12) (2022-08-31)
+
+**Note:** Version bump only for package @rent_avail/avatar
+
+
+
+
+
 ## [0.3.11](https://github.com/rentalutions/elements/compare/@rent_avail/avatar@0.3.10...@rent_avail/avatar@0.3.11) (2022-08-15)
 
 **Note:** Version bump only for package @rent_avail/avatar

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/avatar",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Base styling and theme for Avail Design.",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/packages/controls/CHANGELOG.md
+++ b/packages/controls/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.21](https://github.com/rentalutions/elements/compare/@rent_avail/controls@0.2.20...@rent_avail/controls@0.2.21) (2022-08-31)
+
+**Note:** Version bump only for package @rent_avail/controls
+
+
+
+
+
 ## [0.2.20](https://github.com/rentalutions/elements/compare/@rent_avail/controls@0.2.19...@rent_avail/controls@0.2.20) (2022-04-18)
 
 **Note:** Version bump only for package @rent_avail/controls

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/controls",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "User control components",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -31,7 +31,7 @@
   "dependencies": {
     "@rent_avail/base": "^0.5.0",
     "@rent_avail/core": "^0.0.3",
-    "@rent_avail/popover": "^0.3.10",
+    "@rent_avail/popover": "^0.3.11",
     "@rent_avail/utils": "^0.5.1",
     "framer-motion": "^4.1.17",
     "styled-system": "^5.1.5"

--- a/packages/menu/CHANGELOG.md
+++ b/packages/menu/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.14](https://github.com/rentalutions/elements/compare/@rent_avail/menu@0.2.12...@rent_avail/menu@0.2.14) (2022-08-31)
+
+**Note:** Version bump only for package @rent_avail/menu
+
+
+
+
+
 ## [0.2.13](https://github.com/rentalutions/elements/compare/@rent_avail/menu@0.2.12...@rent_avail/menu@0.2.13) (2022-08-15)
 
 **Note:** Version bump only for package @rent_avail/menu

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/menu",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Menu component",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -31,7 +31,7 @@
   "dependencies": {
     "@rent_avail/base": "^0.5.0",
     "@rent_avail/core": "^0.0.3",
-    "@rent_avail/popover": "^0.3.10",
+    "@rent_avail/popover": "^0.3.11",
     "@rent_avail/utils": "^0.5.1",
     "styled-system": "^5.1.5"
   }

--- a/packages/popover/CHANGELOG.md
+++ b/packages/popover/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.11](https://github.com/rentalutions/elements/compare/@rent_avail/popover@0.3.10...@rent_avail/popover@0.3.11) (2022-08-31)
+
+**Note:** Version bump only for package @rent_avail/popover
+
+
+
+
+
 ## [0.3.10](https://github.com/rentalutions/elements/compare/@rent_avail/popover@0.3.9...@rent_avail/popover@0.3.10) (2022-04-18)
 
 **Note:** Version bump only for package @rent_avail/popover

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/popover",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Popover component",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/packages/select/CHANGELOG.md
+++ b/packages/select/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.16](https://github.com/rentalutions/elements/compare/@rent_avail/select@0.3.15...@rent_avail/select@0.3.16) (2022-08-31)
+
+**Note:** Version bump only for package @rent_avail/select
+
+
+
+
+
 ## [0.3.15](https://github.com/rentalutions/elements/compare/@rent_avail/select@0.3.14...@rent_avail/select@0.3.15) (2022-04-18)
 
 **Note:** Version bump only for package @rent_avail/select

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/select",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Select input component.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -32,7 +32,7 @@
     "@rent_avail/base": "^0.5.0",
     "@rent_avail/input": "^0.4.6",
     "@rent_avail/layout": "^0.3.13",
-    "@rent_avail/popover": "^0.3.10",
+    "@rent_avail/popover": "^0.3.11",
     "@rent_avail/utils": "^0.5.1",
     "clsx": "^1.1.0",
     "react-feather": "^2.0.9",

--- a/packages/tooltip/CHANGELOG.md
+++ b/packages/tooltip/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.11](https://github.com/rentalutions/elements/compare/@rent_avail/tooltip@0.2.10...@rent_avail/tooltip@0.2.11) (2022-08-31)
+
+**Note:** Version bump only for package @rent_avail/tooltip
+
+
+
+
+
 ## [0.2.10](https://github.com/rentalutions/elements/compare/@rent_avail/tooltip@0.2.9...@rent_avail/tooltip@0.2.10) (2022-04-18)
 
 **Note:** Version bump only for package @rent_avail/tooltip

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/tooltip",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Tooltip component",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@rent_avail/base": "^0.5.0",
-    "@rent_avail/popover": "^0.3.10",
+    "@rent_avail/popover": "^0.3.11",
     "@rent_avail/utils": "^0.5.1",
     "styled-system": "^5.1.5"
   }


### PR DESCRIPTION
I found an issue that I don't think was previously discovered as I can't find an example in Avail where we consume a Popover component and pass in a parentRef.

When passing in a parentRef I've refactored the method around calculating the popovers position coordinate, I use the getBoundingClientRec method instead of using the scrollTop and scrollLeft properties which I found are normally 0.

Passing in a parent ref is very useful for inserting the popover next to the button that triggered it for keyboard navigation. I have a feeling in the future when we aim to support keyboard navigation more generally, this property will be used more.