### PR TITLE
Change the style of date value in Safari to match placeholder "look"

### DIFF
--- a/packages/autocomplete/CHANGELOG.md
+++ b/packages/autocomplete/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.18](https://github.com/rentalutions/elements/compare/@rent_avail/autocomplete@0.3.16...@rent_avail/autocomplete@0.3.18) (2022-09-16)
+
+**Note:** Version bump only for package @rent_avail/autocomplete
+
+
+
+
+
 ## [0.3.17](https://github.com/rentalutions/elements/compare/@rent_avail/autocomplete@0.3.16...@rent_avail/autocomplete@0.3.17) (2022-08-31)
 
 **Note:** Version bump only for package @rent_avail/autocomplete

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/autocomplete",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Component and hooks for using Google Places autocomplete.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -30,9 +30,9 @@
   },
   "dependencies": {
     "@rent_avail/base": "^0.5.0",
-    "@rent_avail/input": "^0.4.6",
+    "@rent_avail/input": "^0.4.7",
     "@rent_avail/layout": "^0.3.13",
-    "@rent_avail/popover": "^0.3.11",
+    "@rent_avail/popover": "^0.3.12",
     "@rent_avail/utils": "^0.5.1",
     "styled-system": "^5.1.5"
   }

--- a/packages/controls/CHANGELOG.md
+++ b/packages/controls/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.22](https://github.com/rentalutions/elements/compare/@rent_avail/controls@0.2.20...@rent_avail/controls@0.2.22) (2022-09-16)
+
+**Note:** Version bump only for package @rent_avail/controls
+
+
+
+
+
 ## [0.2.21](https://github.com/rentalutions/elements/compare/@rent_avail/controls@0.2.20...@rent_avail/controls@0.2.21) (2022-08-31)
 
 **Note:** Version bump only for package @rent_avail/controls

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/controls",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "description": "User control components",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -31,7 +31,7 @@
   "dependencies": {
     "@rent_avail/base": "^0.5.0",
     "@rent_avail/core": "^0.0.3",
-    "@rent_avail/popover": "^0.3.11",
+    "@rent_avail/popover": "^0.3.12",
     "@rent_avail/utils": "^0.5.1",
     "framer-motion": "^4.1.17",
     "styled-system": "^5.1.5"

--- a/packages/input/CHANGELOG.md
+++ b/packages/input/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.7](https://github.com/rentalutions/elements/compare/@rent_avail/input@0.4.6...@rent_avail/input@0.4.7) (2022-09-16)
+
+**Note:** Version bump only for package @rent_avail/input
+
+
+
+
+
 ## [0.4.6](https://github.com/rentalutions/elements/compare/@rent_avail/input@0.4.5...@rent_avail/input@0.4.6) (2021-11-08)
 
 

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/input",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Input components",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/packages/input/src/index.js
+++ b/packages/input/src/index.js
@@ -119,7 +119,7 @@ function Input(
               color: "ui_300",
             },
             '&[type="date"]': {
-              color: ref.current?.value ? "ui_900" : "ui_500",
+              color: ref && ref.current?.value ? "ui_900" : "ui_500",
             },
           }}
         />

--- a/packages/input/src/index.js
+++ b/packages/input/src/index.js
@@ -59,7 +59,7 @@ function Input(
           borderStyle: "solid",
           borderColor: "ui_500",
           borderRadius: 4,
-          "&:focus-within": {
+          '&:focus-within, & > [type="date"]:focus-within': {
             borderColor: "blue_500",
             color: "blue_500",
           },
@@ -67,7 +67,7 @@ function Input(
             transform: "translateY(-1rem) scale(0.889)",
           },
           "&.filled:not(:focus-within):not(.error) .input__label-row": {
-            color: disabled ? "ui_500" : "ui_700",
+            color: disabled ? "ui_500" : "ui_900",
           },
           "&.error": {
             borderColor: "red_500",
@@ -118,6 +118,9 @@ function Input(
             "&::-webkit-calendar-picker-indicator:hover + svg": {
               color: "ui_300",
             },
+            '&[type="date"]': {
+              color: ref.current?.value ? "ui_900" : "ui_500",
+            },
           }}
         />
         {isDate && (
@@ -142,7 +145,7 @@ function Input(
             left: icon ? "5rem" : "2rem",
             transformOrigin: "top left",
             pointerEvents: "none",
-            color: disabled ? "ui_500" : "inherit",
+            color: disabled ? "ui_500" : "ui_900",
           }}
         >
           <Box as="span" id={ariaId}>

--- a/packages/input/src/index.js
+++ b/packages/input/src/index.js
@@ -1,5 +1,5 @@
-import React, { forwardRef, useState, useEffect } from "react"
-import { wrapEvent, noop, useId } from "@rent_avail/utils"
+import React, { forwardRef, useState, useEffect, useRef } from "react"
+import { wrapEvent, noop, useId, mergeRefs } from "@rent_avail/utils"
 import { Box } from "@rent_avail/layout"
 import { Calendar } from "react-feather"
 import clsx from "clsx"
@@ -39,6 +39,7 @@ function Input(
   }, [value])
   const systemProps = pick(props)
   const inputProps = omit(props)
+  const inputRef = useRef(null)
   return (
     <Box
       className={className}
@@ -86,7 +87,7 @@ function Input(
       >
         <Box
           {...inputProps}
-          ref={ref}
+          ref={mergeRefs(ref, inputRef)}
           as={as}
           type={type}
           aria-labelledby={[labelledBy, ariaId].join(" ").trim()}
@@ -119,7 +120,7 @@ function Input(
               color: "ui_300",
             },
             '&[type="date"]': {
-              color: ref && ref.current?.value ? "ui_900" : "ui_500",
+              color: inputRef.current?.value ? "ui_900" : "ui_500",
             },
           }}
         />

--- a/packages/menu/CHANGELOG.md
+++ b/packages/menu/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.15](https://github.com/rentalutions/elements/compare/@rent_avail/menu@0.2.13...@rent_avail/menu@0.2.15) (2022-09-16)
+
+**Note:** Version bump only for package @rent_avail/menu
+
+
+
+
+
 ## [0.2.14](https://github.com/rentalutions/elements/compare/@rent_avail/menu@0.2.12...@rent_avail/menu@0.2.14) (2022-08-31)
 
 **Note:** Version bump only for package @rent_avail/menu

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/menu",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Menu component",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -31,7 +31,7 @@
   "dependencies": {
     "@rent_avail/base": "^0.5.0",
     "@rent_avail/core": "^0.0.3",
-    "@rent_avail/popover": "^0.3.11",
+    "@rent_avail/popover": "^0.3.12",
     "@rent_avail/utils": "^0.5.1",
     "styled-system": "^5.1.5"
   }

--- a/packages/popover/CHANGELOG.md
+++ b/packages/popover/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.12](https://github.com/rentalutions/elements/compare/@rent_avail/popover@0.3.10...@rent_avail/popover@0.3.12) (2022-09-16)
+
+**Note:** Version bump only for package @rent_avail/popover
+
+
+
+
+
 ## [0.3.11](https://github.com/rentalutions/elements/compare/@rent_avail/popover@0.3.10...@rent_avail/popover@0.3.11) (2022-08-31)
 
 **Note:** Version bump only for package @rent_avail/popover

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/popover",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Popover component",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/packages/select/CHANGELOG.md
+++ b/packages/select/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.17](https://github.com/rentalutions/elements/compare/@rent_avail/select@0.3.15...@rent_avail/select@0.3.17) (2022-09-16)
+
+**Note:** Version bump only for package @rent_avail/select
+
+
+
+
+
 ## [0.3.16](https://github.com/rentalutions/elements/compare/@rent_avail/select@0.3.15...@rent_avail/select@0.3.16) (2022-08-31)
 
 **Note:** Version bump only for package @rent_avail/select

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/select",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Select input component.",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -30,9 +30,9 @@
   },
   "dependencies": {
     "@rent_avail/base": "^0.5.0",
-    "@rent_avail/input": "^0.4.6",
+    "@rent_avail/input": "^0.4.7",
     "@rent_avail/layout": "^0.3.13",
-    "@rent_avail/popover": "^0.3.11",
+    "@rent_avail/popover": "^0.3.12",
     "@rent_avail/utils": "^0.5.1",
     "clsx": "^1.1.0",
     "react-feather": "^2.0.9",

--- a/packages/tooltip/CHANGELOG.md
+++ b/packages/tooltip/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.12](https://github.com/rentalutions/elements/compare/@rent_avail/tooltip@0.2.10...@rent_avail/tooltip@0.2.12) (2022-09-16)
+
+**Note:** Version bump only for package @rent_avail/tooltip
+
+
+
+
+
 ## [0.2.11](https://github.com/rentalutions/elements/compare/@rent_avail/tooltip@0.2.10...@rent_avail/tooltip@0.2.11) (2022-08-31)
 
 **Note:** Version bump only for package @rent_avail/tooltip

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rent_avail/tooltip",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Tooltip component",
   "source": "src/index.js",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@rent_avail/base": "^0.5.0",
-    "@rent_avail/popover": "^0.3.11",
+    "@rent_avail/popover": "^0.3.12",
     "@rent_avail/utils": "^0.5.1",
     "styled-system": "^5.1.5"
   }


### PR DESCRIPTION
Resolves:
https://moveinc.atlassian.net/browse/AT-4361

In Safari, date inputs are displayed using a generated placeholder value that is today's date. With the current style system, it wasn't clear to users if the placeholder text was actually an entered value or not. This caused even more confusion when they would go to submit a form and they would receive an invalid date error.

This change explicitly styles the text to look like a placeholder when the input has no value, and to look like an entered value when the input contains some value that is not "".

Safari:

https://user-images.githubusercontent.com/106633502/187562936-95230321-61c4-4af6-8e3d-01a910cb85e7.mov

Chrome:

![Screen Shot 2022-08-30 at 4 37 06 PM](https://user-images.githubusercontent.com/106633502/187562950-005cabe1-710b-40fc-89a7-328000c8fa15.png)
