### PR TITLE
Export MenuContext from Menu component.

### DIFF
--- a/packages/menu/src/index.js
+++ b/packages/menu/src/index.js
@@ -268,4 +268,12 @@ function Item({ onClick, closeOnClick, ...props }, ref) {
 
 const MenuItem = memo(forwardRef(Item))
 
+export function useMenuContext() {
+  const context = useContext(MenuContext)
+  if (context === undefined) {
+    throw new Error("MenuContext is undefined.")
+  }
+  return context
+}
+
 export { Menu, MenuTarget, MenuList, MenuItem }


### PR DESCRIPTION
Export MenuContext from Menu component to access isOpen state at consumer side of menu, based on which lockscroll and unlockscroll can be achieved (AT-4620).