### PR TITLE
[RENA-4893] Fix Broken "Select" Storybook

### DIFF
--- a/packages/controls/stories/_controls.stories.mdx
+++ b/packages/controls/stories/_controls.stories.mdx
@@ -10,7 +10,7 @@ import {
   SelectItem,
   Switch,
 } from "../src"
-import { SelectStory } from "./select.story"
+import { SelectUsage } from "./controls.stories"
 
 <Meta title="Packages / Controls" />
 
@@ -120,5 +120,5 @@ Text inputs let users enter and edit text information. They are made up of a lab
 ## Select
 
 <Canvas>
-  <Story story={SelectStory} name="Select" />
+  <Story story={SelectUsage} name="Select" />
 </Canvas>

--- a/packages/controls/stories/controls.stories.js
+++ b/packages/controls/stories/controls.stories.js
@@ -79,7 +79,7 @@ export function SelectUsage() {
   }, [])
   if (!state.loaded) return "loading..."
   return (
-    <Container>
+    <Container sx={{ py: "2rem" }}>
       <Select id="home-address">
         <SelectInput label="Home State" />
         <SelectList>


### PR DESCRIPTION
|Type|URL|
| - | - |
|JIRA Ticket|https://moveinc.atlassian.net/browse/RENA-4893|
|Github Issue|https://github.com/rentalutions/elements/issues/233|

### Why

It seems that code for an older (outdated) version of the select input was being used and included in the storybook. This version did not include token as props to the `SelectItem` component, and as a result, the page completely broke.

Please visit https://design.avail.co/?path=/story/packages-controls--select-story to see the error provided as a screenshot below.

### Solution

We already had a working example of the updated `Select` component, and it just wasn't being used. The small changes here point to using the working storybook component.

### Expected behavior

`Select` input storybook works as expected

### Screenshots

|Screenshot|
| - |
|![Screen Shot 2023-11-16 at 12 40 19 PM](https://github.com/rentalutions/elements/assets/29084739/396c9961-9df9-4329-916d-95df930c780a)|

