### PR TITLE
[RENA-6114] Improve Storybook for Icons Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ A set of components built to be `composable`, `extendable`, and `usable`
 
 1. Clone the repo with `gh repo clone rentalutions/elements`.
 2. Install dependencies with `yarn install`.
-3. Start a storybook container that builds all the packages and watches for changes with `yarn start`.
+3. Start a storybook container that builds all the packages and watches for changes with:
+    * `yarn build:storybook`
+    * `yarn dev:storybook`
 
 ## Project Structure
 

--- a/packages/icons/stories/default.story.js
+++ b/packages/icons/stories/default.story.js
@@ -16,11 +16,12 @@ export function Icons() {
           title={icon.displayName}
           sx={{
             m: "1rem",
-            p: "1rem",
+            p: "2rem",
             width: "10rem",
             flexDirection: "column",
             justifyContent: "center",
             alignItems: "center",
+            rowGap: "1rem",
             bg: "ui_100",
             borderRadius: "4px",
             boxShadow: `0px 1px 5px ${baseTheme.colors.ui_500}`,
@@ -30,7 +31,7 @@ export function Icons() {
           }}
         >
           <Box as={icon} />
-          <Box sx={{ text: "small", fontSize: "1rem", mt: "1rem" }}>{icon.displayName}</Box>
+          <Box sx={{ text: "small", fontSize: "1rem" }}>{icon.displayName}</Box>
         </Flex>
       ))}
     </Container>

--- a/packages/icons/stories/default.story.js
+++ b/packages/icons/stories/default.story.js
@@ -9,7 +9,7 @@ for (let icon in icons) {
 
 export function Icons() {
   return (
-    <Container as={Flex} sx={{ p: "2rem", my: "2rem", flexWrap: "wrap", justifyContent: "center" }}>
+    <Container as={Flex} sx={{ p: "2rem", flexWrap: "wrap", justifyContent: "center" }}>
       {iconsArray.map((icon) => (
         <Flex
           key={icon.displayName}

--- a/packages/icons/stories/default.story.js
+++ b/packages/icons/stories/default.story.js
@@ -1,5 +1,5 @@
 import * as icons from "../src"
-import { Box, Container } from "@rent_avail/core"
+import { Card, Flex, Box, Container } from "@rent_avail/core"
 
 const iconsArray = []
 
@@ -10,9 +10,30 @@ for (let icon in icons) {
 export function Icons() {
   return (
     <Container sx={{ pt: "2rem" }}>
-      {iconsArray.map((icon) => (
-        <Box as={icon} sx={{ m: "1rem" }} />
-      ))}
+      <Card as={Flex} sx={{ p: "2rem", my: "2rem", flexWrap: "wrap", justifyContent: "center" }}>
+        {iconsArray.map((icon) => (
+          <Flex
+            key={icon.displayName}
+            title={icon.displayName}
+            sx={{
+              m: "1rem",
+              p: "1rem",
+              width: "10rem",
+              flexDirection: "column",
+              justifyContent: "center",
+              alignItems: "center",
+              bg: "ui_300",
+              borderRadius: "4px",
+              "&:hover": {
+                bg: "ui_500",
+              }
+            }}
+          >
+            <Box as={icon} />
+            <Box sx={{ text: "small", fontSize: "1rem", mt: "1rem" }}>{icon.displayName}</Box>
+          </Flex>
+        ))}
+      </Card>
     </Container>
   )
 }

--- a/packages/icons/stories/default.story.js
+++ b/packages/icons/stories/default.story.js
@@ -1,5 +1,5 @@
 import * as icons from "../src"
-import { Card, Flex, Box, Container } from "@rent_avail/core"
+import { Flex, Box, Container, baseTheme } from "@rent_avail/core"
 
 const iconsArray = []
 
@@ -9,31 +9,30 @@ for (let icon in icons) {
 
 export function Icons() {
   return (
-    <Container sx={{ pt: "2rem" }}>
-      <Card as={Flex} sx={{ p: "2rem", my: "2rem", flexWrap: "wrap", justifyContent: "center" }}>
-        {iconsArray.map((icon) => (
-          <Flex
-            key={icon.displayName}
-            title={icon.displayName}
-            sx={{
-              m: "1rem",
-              p: "1rem",
-              width: "10rem",
-              flexDirection: "column",
-              justifyContent: "center",
-              alignItems: "center",
-              bg: "ui_300",
-              borderRadius: "4px",
-              "&:hover": {
-                bg: "ui_500",
-              }
-            }}
-          >
-            <Box as={icon} />
-            <Box sx={{ text: "small", fontSize: "1rem", mt: "1rem" }}>{icon.displayName}</Box>
-          </Flex>
-        ))}
-      </Card>
+    <Container as={Flex} sx={{ p: "2rem", my: "2rem", flexWrap: "wrap", justifyContent: "center" }}>
+      {iconsArray.map((icon) => (
+        <Flex
+          key={icon.displayName}
+          title={icon.displayName}
+          sx={{
+            m: "1rem",
+            p: "1rem",
+            width: "10rem",
+            flexDirection: "column",
+            justifyContent: "center",
+            alignItems: "center",
+            bg: "ui_100",
+            borderRadius: "4px",
+            boxShadow: `0px 1px 5px ${baseTheme.colors.ui_500}`,
+            "&:hover": {
+              boxShadow: `0px 1px 5px ${baseTheme.colors.ui_700}`,
+            }
+          }}
+        >
+          <Box as={icon} />
+          <Box sx={{ text: "small", fontSize: "1rem", mt: "1rem" }}>{icon.displayName}</Box>
+        </Flex>
+      ))}
     </Container>
   )
 }


### PR DESCRIPTION
|Type|URL|
| - | - |
|JIRA Ticket|https://moveinc.atlassian.net/browse/RENA-6114|

### Why

Documentation for the icons for the Avail Design Kit found at https://design.avail.co/?path=/story/packages-icons--icons is extremely limited and requires inspecting the elements or looking at the source code to get element names.

Storybook should be improved to include names for each icon component.

### Solution

Include component names for each icon on the storybook page and minor update to UI to keep icons less congested.

The new UI brings us slightly closer to what we can see for https://feathericons.com/.

### Expected behavior

Component names are included when viewing the storybook page for icons

### Also Included

Update `README.md` since it's outdated and the current steps to setup and run locally do not work.

### Screenshots

|Before|After|
| - | - |
|![Screen Shot 2024-03-01 at 2 48 01 PM](https://github.com/rentalutions/elements/assets/29084739/1be3be44-1a7c-4716-a4e3-d852de53699d)|![Screen Shot 2024-03-01 at 3 37 24 PM](https://github.com/rentalutions/elements/assets/29084739/b63b3292-c7c5-448f-a704-053945a90a02)|

