### PR TITLE
[RENA-6249] Date Picker is not showing when clicking the calendar icon

### DIFF
--- a/packages/controls/src/input.js
+++ b/packages/controls/src/input.js
@@ -118,7 +118,6 @@ export const Input = forwardRef(function Input(
               position: "absolute",
               right: "2rem",
               top: "3rem",
-              zIndex: 100,
               fontSize: "24px",
             },
             "&::-webkit-calendar-picker-indicator:hover + svg": {
@@ -138,7 +137,6 @@ export const Input = forwardRef(function Input(
               position: "absolute",
               right: "2rem",
               top: "3rem",
-              cursor: "pointer",
             }}
           />
         )}

--- a/packages/controls/src/input.js
+++ b/packages/controls/src/input.js
@@ -115,6 +115,11 @@ export const Input = forwardRef(function Input(
               background: "transparent",
               opacity: 1,
               cursor: "pointer",
+              position: "absolute",
+              right: "2rem",
+              top: "3rem",
+              zIndex: 100,
+              fontSize: "24px",
             },
             "&::-webkit-calendar-picker-indicator:hover + svg": {
               color: "ui_300",
@@ -133,6 +138,7 @@ export const Input = forwardRef(function Input(
               position: "absolute",
               right: "2rem",
               top: "3rem",
+              cursor: "pointer",
             }}
           />
         )}

--- a/packages/controls/stories/_controls.stories.mdx
+++ b/packages/controls/stories/_controls.stories.mdx
@@ -67,7 +67,7 @@ Checkboxes are user selection tools when multiple options can be chosen at the s
 
 <Canvas>
   <Story name="Date">
-    <Container as={Flex} sx={{ p: "2rem", flexDirection: "column" }}>
+    <Container>
       <Box as="section">
         <Input type="date" label="Start Date" />
       </Box>
@@ -114,6 +114,12 @@ Radio buttons are used to select one option from a set. Use radio buttons when i
 
 <ArgsTable of={Radio} />
 
+## Select
+
+<Canvas>
+  <Story story={SelectUsage} name="Select" />
+</Canvas>
+
 ## Switch
 
 Switches selection controls that change data immediately. They need to be understood as a boolean (on/off). Toggles are the preferred way to update settings on mobile.
@@ -128,9 +134,3 @@ Switches selection controls that change data immediately. They need to be unders
 </Canvas>
 
 <ArgsTable of={Switch} />
-
-## Select
-
-<Canvas>
-  <Story story={SelectUsage} name="Select" />
-</Canvas>

--- a/packages/controls/stories/_controls.stories.mdx
+++ b/packages/controls/stories/_controls.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs"
-import { Flex, Box } from "@rent_avail/core"
+import { Container, Box, Flex } from "@rent_avail/core"
 import { Search } from "@rent_avail/icons"
 import {
   Button,
@@ -63,6 +63,40 @@ Checkboxes are user selection tools when multiple options can be chosen at the s
 
 <ArgsTable of={Checkbox} />
 
+## Date
+
+<Canvas>
+  <Story name="Date">
+    <Container as={Flex} sx={{ p: "2rem", flexDirection: "column" }}>
+      <Box as="section">
+        <Input type="date" label="Start Date" />
+      </Box>
+    </Container>
+  </Story>
+</Canvas>
+
+## Input
+
+Text inputs let users enter and edit text information. They are made up of a label, value, helper text, and optionally a leading / trailing icon.
+
+<Canvas isColumn>
+  <Story name="Input">
+    <Input icon={Search} label="Find Your Next Property" />
+  </Story>
+  <Story name="Input Disabled">
+    <Input icon={Search} label="Find Your Next Property" disabled />
+  </Story>
+  <Story name="Input Error">
+    <Input
+      icon={Search}
+      label="Find Your Next Property"
+      error="Property Not Found"
+    />
+  </Story>
+</Canvas>
+
+<ArgsTable of={Input} />
+
 ---
 
 ## Radio
@@ -94,28 +128,6 @@ Switches selection controls that change data immediately. They need to be unders
 </Canvas>
 
 <ArgsTable of={Switch} />
-
-## Input
-
-Text inputs let users enter and edit text information. They are made up of a label, value, helper text, and optionally a leading / trailing icon.
-
-<Canvas isColumn>
-  <Story name="Input">
-    <Input icon={Search} label="Find Your Next Property" />
-  </Story>
-  <Story name="Input Error">
-    <Input
-      icon={Search}
-      label="Find Your Next Property"
-      error="Property Not Found"
-    />
-  </Story>
-  <Story name="Input Disabled">
-    <Input icon={Search} label="Find Your Next Property" disabled />
-  </Story>
-</Canvas>
-
-<ArgsTable of={Input} />
 
 ## Select
 

--- a/packages/controls/stories/_controls.stories.mdx
+++ b/packages/controls/stories/_controls.stories.mdx
@@ -63,15 +63,11 @@ Checkboxes are user selection tools when multiple options can be chosen at the s
 
 <ArgsTable of={Checkbox} />
 
-## Date
+## Date Input
 
 <Canvas>
-  <Story name="Date">
-    <Container>
-      <Box as="section">
-        <Input type="date" label="Start Date" />
-      </Box>
-    </Container>
+  <Story name="Date Input">
+    <Input type="date" label="Start Date" />
   </Story>
 </Canvas>
 


### PR DESCRIPTION
## Resolves
https://moveinc.atlassian.net/browse/RENA-6249

## Why
The date picker UI no longer shows when clicking the calendar icon.

## Solution
Explicitly position the input date picker default icon behind the calendar icon.

| Page | Screenshot |
| --- | ------ |
| Canvas | <img width="1840" alt="image" src="https://github.com/rentalutions/elements/assets/106633502/928d1b5f-d0cb-4073-864b-fa7605541b5e"> |
| Docs | <img width="1840" alt="image" src="https://github.com/rentalutions/elements/assets/106633502/bf40f4bc-eb2a-4bed-9269-ea1e80d5d77e"> |

