### PR TITLE
[RENA-6556] Update "Switch" off state background color

### DIFF
--- a/packages/controls/src/switch.js
+++ b/packages/controls/src/switch.js
@@ -37,7 +37,7 @@ export const Switch = forwardRef(function Switch(
           position: "relative",
           height: "2rem",
           width: "4rem",
-          bg: "background.secondary",
+          bg: "interactive.secondary",
           borderRadius: "1rem",
           transition: "200ms",
           flexShrink: 0,

--- a/packages/core/src/base-theme.ts
+++ b/packages/core/src/base-theme.ts
@@ -41,7 +41,7 @@ const baseColors = {
 const availColors = {
   background: {
     primary: baseColors.ui_100,
-    secondary: baseColors.ui_500,
+    secondary: baseColors.ui_300,
     reverse: baseColors.ui_900,
     overlay: transparentize(0.3, baseColors.ui_900),
   },
@@ -62,6 +62,7 @@ const availColors = {
   },
   interactive: {
     default: baseColors.ui_900,
+    secondary: baseColors.ui_500,
     hover: baseColors.ui_700,
     focus: baseColors.blue_500,
     disabled: baseColors.ui_500,

--- a/packages/core/src/base-theme.ts
+++ b/packages/core/src/base-theme.ts
@@ -41,7 +41,7 @@ const baseColors = {
 const availColors = {
   background: {
     primary: baseColors.ui_100,
-    secondary: baseColors.ui_300,
+    secondary: baseColors.ui_500,
     reverse: baseColors.ui_900,
     overlay: transparentize(0.3, baseColors.ui_900),
   },


### PR DESCRIPTION
### Resolves

|Type|URL|
| - | - |
|JIRA Ticket|https://moveinc.atlassian.net/browse/RENA-6556|

### Why

Last year there was an [update](https://github.com/rentalutions/elements/pull/213/files#diff-f57fead3f2ce21739fc0bf5adad5b9bdb86f59cf48f99820f28118bcea363c18) to the Switch component in the elements repo that changed the background color when the switch is "off". This clashes with some of the background colors in Avail, using the exact same color and does not appear to be an intentional change.

This can be easily overridden with custom styling, but fixing it at the source means we won’t require any custom styling to use the component properly.

It can be seen in the Elements Repo storybook that when the switch is off, the background blends with the background in storybook:
* https://design.avail.co/?path=/story/packages-controls--switch-story

The color used to be ui_500 color, but now it’s ui_300, and should be reverted to the original color to prevent issues in the UI.

### Solution

Update the `baseTheme` `background.secondary` color. Currently it's only being used in the switch component, so I don't see this change as having too much of an impact elsewhere.

### Screenshots

|Before|After|
| - | - |
|![Screen Shot 2024-04-08 at 4 24 59 PM](https://github.com/rentalutions/elements/assets/29084739/878272fa-bf0a-4760-84ab-188213083a37)|![Screen Shot 2024-04-08 at 4 26 27 PM](https://github.com/rentalutions/elements/assets/29084739/05c530b8-d09b-49c1-8555-39420aebcfcf)|
