### PR TITLE
Update Github Publish Package workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,14 @@
 name: Publish Packages
 
 on:
-  push:
+  pull_request:
     branches: [release]
+    types: [closed]
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'graduate-')
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1


### PR DESCRIPTION
### Jira ticket

https://moveinc.atlassian.net/browse/RENA-6902

### Description

Update Github workflow to not attempt to _Publish Package_ unless:
- `release` is updated through a PR.
- The PR is _merged_.
- The PR branch is prefixed with "graduate-".