### PR TITLE
[RENA-7152] "Avatar" default image is broken because it accesses an s3 bucket that was replaced and renamed

### DIFF
--- a/packages/avatar/src/index.js
+++ b/packages/avatar/src/index.js
@@ -20,11 +20,11 @@ function AvatarGroup({ sx = {}, clipColor = "ui_100", ...props }) {
 }
 
 const defaultPhoto =
-  "https://rentalutions-assets.s3.amazonaws.com/avatars/not-found.svg"
+  "https://prod-avail-assets.s3.amazonaws.com/avatars/not-found.svg"
 
 const Avatar = forwardRef(function Avatar(
   {
-    photo = "https://rentalutions-assets.s3.amazonaws.com/avatars/not-found.svg",
+    photo = defaultPhoto,
     name,
     email,
     size = "large",

--- a/packages/avatar/stories/_avatar.stories.mdx
+++ b/packages/avatar/stories/_avatar.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story } from "@storybook/addon-docs"
-import { Default, NoEmail } from "./avatar.stories"
+import { Default, NoEmail, NoPhotoOrInitials } from "./avatar.stories"
 
 <Meta title="Packages / Avatar" />
 
@@ -26,6 +26,10 @@ import Avatar, { AvatarGroup } from "@rent_avail/avatar"
   />
 </Flex>
 ```
+
+Without a photo or initials, render a default image for the avatar
+
+<Story story={NoPhotoOrInitials} />
 
 ### Description
 

--- a/packages/avatar/stories/avatar.stories.js
+++ b/packages/avatar/stories/avatar.stories.js
@@ -21,6 +21,15 @@ export function Default() {
   )
 }
 
+export function NoPhotoOrInitials() {
+  return (
+    <Avatar
+      name="Chicago Properties & Financials of Streeterville Coast"
+      email="janet.wooderhousen@email.com"
+    />
+  )
+}
+
 export function NoEmail() {
   return (
     <Fragment>


### PR DESCRIPTION
## Resolves

https://moveinc.atlassian.net/browse/RENA-7152

## Why

When doing some local testing of the e-signature flow in the Avail monolith, I noticed that the default images for the Avatar component were broken. Some light investigation showed that we’re using an old S3 bucket hardcoded into the codebase.
* https://github.com/rentalutions/elements/blob/release/packages/avatar/src/index.js#L22-L23

## Solution

Update the URL to access valid bucket (prod, for now)

## Also Included

Add `Avatar` storybook component for when the default image would be displayed

## Screenshots

|Broken images in Avail Monolith|
|-|
|![Screenshot 2024-06-04 at 3 51 37 PM](https://github.com/rentalutions/elements/assets/29084739/bef73698-b343-4b1c-9b8f-29632c5a3e15)|

**Design Kit Storybook**

|Before fixing S3 URL|After fixing S3 URL|
| - | - |
|![Screenshot 2024-06-04 at 3 41 25 PM](https://github.com/rentalutions/elements/assets/29084739/0a7f50ad-4bec-4822-b5b4-014fad649fdf)|![Screenshot 2024-06-04 at 3 41 49 PM](https://github.com/rentalutions/elements/assets/29084739/c0688abe-b88b-4574-8beb-58c446ac4f34)|
